### PR TITLE
feat: implement rollover balance functionality for tracking budget

### DIFF
--- a/packages/desktop-client/src/components/budget/tracking/TrackingBudgetComponents.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/TrackingBudgetComponents.tsx
@@ -58,7 +58,7 @@ export const useTrackingSheetValue = <
   return useSheetValue(binding);
 };
 
-const TrackingCellValue = <FieldName extends SheetFields<'tracking-budget'>>(
+export const TrackingCellValue = <FieldName extends SheetFields<'tracking-budget'>>(
   props: ComponentProps<typeof CellValue<'tracking-budget', FieldName>>,
 ) => {
   return <CellValue {...props} />;

--- a/packages/desktop-client/src/components/budget/tracking/TrackingCoverMenu.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/TrackingCoverMenu.tsx
@@ -1,0 +1,104 @@
+import React, { useMemo, useState } from 'react';
+import { Form } from 'react-aria-components';
+import { Trans, useTranslation } from 'react-i18next';
+
+import { Button } from '@actual-app/components/button';
+import { InitialFocus } from '@actual-app/components/initial-focus';
+import { View } from '@actual-app/components/view';
+
+import { type CategoryEntity } from 'loot-core/types/models';
+
+import { CategoryAutocomplete } from '@desktop-client/components/autocomplete/CategoryAutocomplete';
+import {
+  addToBeBudgetedGroup,
+  removeCategoriesFromGroups,
+} from '@desktop-client/components/budget/util';
+import { useCategories } from '@desktop-client/hooks/useCategories';
+
+type TrackingCoverMenuProps = {
+  showToBeBudgeted?: boolean;
+  categoryId?: CategoryEntity['id'];
+  onSubmit: (categoryId: CategoryEntity['id']) => void;
+  onClose: () => void;
+};
+
+export function TrackingCoverMenu({
+  showToBeBudgeted = true,
+  categoryId,
+  onSubmit,
+  onClose,
+}: TrackingCoverMenuProps) {
+  const { t } = useTranslation();
+
+  const { grouped: originalCategoryGroups } = useCategories();
+
+  const [fromCategoryId, setFromCategoryId] = useState<string | null>(null);
+
+  const filteredCategoryGroups = useMemo(() => {
+    const expenseGroups = originalCategoryGroups.filter(g => !g.is_income);
+    const categoryGroups = showToBeBudgeted
+      ? addToBeBudgetedGroup(expenseGroups)
+      : expenseGroups;
+    return categoryId
+      ? removeCategoriesFromGroups(categoryGroups, categoryId)
+      : categoryGroups;
+  }, [categoryId, showToBeBudgeted, originalCategoryGroups]);
+
+  function _onSubmit() {
+    if (fromCategoryId) {
+      onSubmit(fromCategoryId);
+    }
+    onClose();
+  }
+
+  return (
+    <Form
+      onSubmit={e => {
+        e.preventDefault();
+        _onSubmit();
+      }}
+    >
+      <View style={{ padding: 10 }}>
+        <View style={{ marginBottom: 5 }}>
+          <Trans>Cover from a category:</Trans>
+        </View>
+
+        <InitialFocus<HTMLInputElement>>
+          {node => (
+            <CategoryAutocomplete
+              categoryGroups={filteredCategoryGroups}
+              value={null}
+              openOnFocus={true}
+              onSelect={(id: string | undefined) =>
+                setFromCategoryId(id || null)
+              }
+              inputProps={{
+                ref: node,
+                placeholder: t('(none)'),
+              }}
+              showHiddenCategories={false}
+            />
+          )}
+        </InitialFocus>
+
+        <View
+          style={{
+            alignItems: 'flex-end',
+            marginTop: 10,
+          }}
+        >
+          <Button
+            type="submit"
+            variant="primary"
+            style={{
+              fontSize: 12,
+              paddingTop: 3,
+            }}
+          >
+            <Trans>Transfer</Trans>
+          </Button>
+        </View>
+      </View>
+    </Form>
+  );
+} 

--- a/packages/desktop-client/src/components/budget/tracking/TrackingHoldMenu.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/TrackingHoldMenu.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import { Form } from 'react-aria-components';
+import { Trans } from 'react-i18next';
+
+import { Button } from '@actual-app/components/button';
+import { InitialFocus } from '@actual-app/components/initial-focus';
+import { Input } from '@actual-app/components/input';
+import { View } from '@actual-app/components/view';
+
+import { evalArithmetic } from 'loot-core/shared/arithmetic';
+import { integerToCurrency, amountToInteger } from 'loot-core/shared/util';
+
+import { useTrackingSheetValue } from '@desktop-client/components/budget/tracking/TrackingBudgetComponents';
+import { trackingBudget } from '@desktop-client/spreadsheet/bindings';
+
+type TrackingHoldMenuProps = {
+  onSubmit: (amount: number) => void;
+  onClose: () => void;
+};
+
+export function TrackingHoldMenu({ onSubmit, onClose }: TrackingHoldMenuProps) {
+  const [amount, setAmount] = useState<string | null>(null);
+
+  const toBudgetValue = useTrackingSheetValue(trackingBudget.toBudget);
+  
+  React.useEffect(() => {
+    if (toBudgetValue !== null && toBudgetValue !== undefined) {
+      setAmount(integerToCurrency(Math.max(toBudgetValue || 0, 0)));
+    }
+  }, [toBudgetValue]);
+
+  function _onSubmit(newAmount: string) {
+    const parsedAmount = evalArithmetic(newAmount);
+    if (parsedAmount) {
+      onSubmit(amountToInteger(parsedAmount));
+    }
+    onClose();
+  }
+
+  if (amount === null) {
+    // See `TransferMenu` for more info about this
+    return null;
+  }
+
+  return (
+    <Form
+      onSubmit={e => {
+        e.preventDefault();
+        _onSubmit(amount);
+      }}
+    >
+      <View style={{ padding: 10 }}>
+        <View style={{ marginBottom: 5 }}>
+          <Trans>Hold this amount:</Trans>
+        </View>
+        <View>
+          <InitialFocus>
+            <Input value={amount} onChangeValue={setAmount} />
+          </InitialFocus>
+        </View>
+        <View
+          style={{
+            alignItems: 'flex-end',
+            marginTop: 10,
+          }}
+        >
+          <Button
+            type="submit"
+            variant="primary"
+            style={{
+              fontSize: 12,
+              paddingTop: 3,
+              paddingBottom: 3,
+            }}
+          >
+            <Trans>Hold</Trans>
+          </Button>
+        </View>
+      </View>
+    </Form>
+  );
+} 

--- a/packages/desktop-client/src/components/budget/tracking/TrackingTransferMenu.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/TrackingTransferMenu.tsx
@@ -1,0 +1,112 @@
+import React, { useMemo, useState } from 'react';
+import { Form } from 'react-aria-components';
+import { Trans } from 'react-i18next';
+
+import { Button } from '@actual-app/components/button';
+import { InitialFocus } from '@actual-app/components/initial-focus';
+import { Input } from '@actual-app/components/input';
+import { View } from '@actual-app/components/view';
+
+import { evalArithmetic } from 'loot-core/shared/arithmetic';
+import { integerToCurrency, amountToInteger } from 'loot-core/shared/util';
+import { type CategoryEntity } from 'loot-core/types/models';
+
+import { CategoryAutocomplete } from '@desktop-client/components/autocomplete/CategoryAutocomplete';
+import {
+  addToBeBudgetedGroup,
+  removeCategoriesFromGroups,
+} from '@desktop-client/components/budget/util';
+import { useCategories } from '@desktop-client/hooks/useCategories';
+
+type TrackingTransferMenuProps = {
+  categoryId?: CategoryEntity['id'];
+  initialAmount?: number;
+  showToBeBudgeted?: boolean;
+  onSubmit: (amount: number, categoryId: CategoryEntity['id']) => void;
+  onClose: () => void;
+};
+
+export function TrackingTransferMenu({
+  categoryId,
+  initialAmount = 0,
+  showToBeBudgeted,
+  onSubmit,
+  onClose,
+}: TrackingTransferMenuProps) {
+  const { grouped: originalCategoryGroups } = useCategories();
+  const filteredCategoryGroups = useMemo(() => {
+    const expenseCategoryGroups = originalCategoryGroups.filter(
+      g => !g.is_income,
+    );
+    const categoryGroups = showToBeBudgeted
+      ? addToBeBudgetedGroup(expenseCategoryGroups)
+      : expenseCategoryGroups;
+    return categoryId
+      ? removeCategoriesFromGroups(categoryGroups, categoryId)
+      : categoryGroups;
+  }, [originalCategoryGroups, categoryId, showToBeBudgeted]);
+
+  const _initialAmount = integerToCurrency(Math.max(initialAmount, 0));
+  const [amount, setAmount] = useState<string | null>(null);
+  const [toCategoryId, setToCategoryId] = useState<string | null>(null);
+
+  const _onSubmit = (newAmount: string | null, categoryId: string | null) => {
+    const parsedAmount = evalArithmetic(newAmount || '');
+    if (parsedAmount && categoryId) {
+      onSubmit?.(amountToInteger(parsedAmount), categoryId);
+    }
+
+    onClose();
+  };
+
+  return (
+    <Form
+      onSubmit={e => {
+        e.preventDefault();
+        _onSubmit(amount, toCategoryId);
+      }}
+    >
+      <View style={{ padding: 10 }}>
+        <View style={{ marginBottom: 5 }}>
+          <Trans>Transfer this amount:</Trans>
+        </View>
+        <View>
+          <InitialFocus>
+            <Input defaultValue={_initialAmount} onUpdate={setAmount} />
+          </InitialFocus>
+        </View>
+        <View style={{ margin: '10px 0 5px 0' }}>To:</View>
+
+        <CategoryAutocomplete
+          categoryGroups={filteredCategoryGroups}
+          value={null}
+          openOnFocus={true}
+          onSelect={(id: string | undefined) => setToCategoryId(id || null)}
+          inputProps={{
+            placeholder: '(none)',
+          }}
+          showHiddenCategories={true}
+        />
+
+        <View
+          style={{
+            alignItems: 'flex-end',
+            marginTop: 10,
+          }}
+        >
+          <Button
+            type="submit"
+            variant="primary"
+            style={{
+              fontSize: 12,
+              paddingTop: 3,
+              paddingBottom: 3,
+            }}
+          >
+            <Trans>Transfer</Trans>
+          </Button>
+        </View>
+      </View>
+    </Form>
+  );
+} 

--- a/packages/desktop-client/src/components/budget/tracking/budgetsummary/BudgetSummary.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/budgetsummary/BudgetSummary.tsx
@@ -21,6 +21,8 @@ import { BudgetMonthMenu } from './BudgetMonthMenu';
 import { ExpenseTotal } from './ExpenseTotal';
 import { IncomeTotal } from './IncomeTotal';
 import { Saved } from './Saved';
+import { TrackingTotalsList } from './TrackingTotalsList';
+import { TrackingToBudget } from './TrackingToBudget';
 
 import { useTrackingBudget } from '@desktop-client/components/budget/tracking/TrackingBudgetContext';
 import { NotesButton } from '@desktop-client/components/NotesButton';
@@ -242,19 +244,39 @@ export function BudgetSummary({ month }: BudgetSummaryProps) {
         </View>
 
         {!collapsed && (
-          <Stack
-            spacing={2}
-            style={{
-              alignSelf: 'center',
-              backgroundColor: theme.tableRowHeaderBackground,
-              borderRadius: 4,
-              padding: '10px 15px',
-              marginTop: 13,
-            }}
-          >
-            <IncomeTotal />
-            <ExpenseTotal />
-          </Stack>
+          <>
+            <TrackingTotalsList
+              prevMonthName={monthUtils.format(monthUtils.prevMonth(month), 'MMM', locale)}
+              style={{
+                padding: '5px 0',
+                marginTop: 17,
+                backgroundColor: theme.tableRowHeaderBackground,
+                borderTopWidth: 1,
+                borderBottomWidth: 1,
+                borderColor: theme.tableBorder,
+              }}
+            />
+            <View style={{ margin: '23px 0' }}>
+              <TrackingToBudget
+                prevMonthName={monthUtils.format(monthUtils.prevMonth(month), 'MMM', locale)}
+                month={month}
+                onBudgetAction={onBudgetAction}
+              />
+            </View>
+            <Stack
+              spacing={2}
+              style={{
+                alignSelf: 'center',
+                backgroundColor: theme.tableRowHeaderBackground,
+                borderRadius: 4,
+                padding: '10px 15px',
+                marginTop: 13,
+              }}
+            >
+              <IncomeTotal />
+              <ExpenseTotal />
+            </Stack>
+          </>
         )}
 
         {collapsed ? (
@@ -267,7 +289,12 @@ export function BudgetSummary({ month }: BudgetSummaryProps) {
               borderTop: '1px solid ' + theme.tableBorder,
             }}
           >
-            <Saved projected={month >= currentMonth} />
+            <TrackingToBudget
+              prevMonthName={monthUtils.format(monthUtils.prevMonth(month), 'MMM', locale)}
+              month={month}
+              onBudgetAction={onBudgetAction}
+              isCollapsed
+            />
           </View>
         ) : (
           <Saved

--- a/packages/desktop-client/src/components/budget/tracking/budgetsummary/TrackingToBudget.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/budgetsummary/TrackingToBudget.tsx
@@ -1,0 +1,147 @@
+import React, {
+  type CSSProperties,
+  useCallback,
+  useRef,
+  useState,
+} from 'react';
+
+import { Popover } from '@actual-app/components/popover';
+import { View } from '@actual-app/components/view';
+
+import { TrackingToBudgetAmount } from './TrackingToBudgetAmount';
+import { TrackingToBudgetMenu } from './TrackingToBudgetMenu';
+import { TrackingHoldMenu } from '@desktop-client/components/budget/tracking/TrackingHoldMenu';
+import { TrackingTransferMenu } from '@desktop-client/components/budget/tracking/TrackingTransferMenu';
+import { TrackingCoverMenu } from '@desktop-client/components/budget/tracking/TrackingCoverMenu';
+
+import { useTrackingSheetValue } from '@desktop-client/components/budget/tracking/TrackingBudgetComponents';
+import { useContextMenu } from '@desktop-client/hooks/useContextMenu';
+import { trackingBudget } from '@desktop-client/spreadsheet/bindings';
+
+type TrackingToBudgetProps = {
+  month: string;
+  onBudgetAction: (month: string, action: string, arg?: unknown) => void;
+  prevMonthName: string;
+  style?: CSSProperties;
+  amountStyle?: CSSProperties;
+  isCollapsed?: boolean;
+};
+
+export function TrackingToBudget({
+  month,
+  prevMonthName,
+  onBudgetAction,
+  style,
+  amountStyle,
+  isCollapsed = false,
+}: TrackingToBudgetProps) {
+  const [menuStep, _setMenuStep] = useState<string>('actions');
+  const triggerRef = useRef(null);
+
+  const ref = useRef<HTMLSpanElement>(null);
+  const setMenuStep = useCallback(
+    (menu: string) => {
+      if (menu) ref.current?.focus();
+      _setMenuStep(menu);
+    },
+    [ref, _setMenuStep],
+  );
+  
+  const availableValue = useTrackingSheetValue({
+    name: trackingBudget.toBudget,
+    value: 0,
+  });
+  
+  if (typeof availableValue !== 'number' && availableValue !== null) {
+    throw new Error(
+      'Expected availableValue to be a number but got ' + availableValue,
+    );
+  }
+
+  const {
+    setMenuOpen,
+    menuOpen,
+    handleContextMenu,
+    resetPosition,
+    position,
+    asContextMenu,
+  } = useContextMenu();
+
+  return (
+    <>
+      <View ref={triggerRef}>
+        <TrackingToBudgetAmount
+          onClick={() => {
+            resetPosition();
+            setMenuOpen(true);
+          }}
+          prevMonthName={prevMonthName}
+          style={style}
+          amountStyle={amountStyle}
+          isTotalsListTooltipDisabled={!isCollapsed || menuOpen}
+          onContextMenu={handleContextMenu}
+        />
+      </View>
+
+      <Popover
+        triggerRef={triggerRef}
+        placement={asContextMenu ? 'bottom start' : 'bottom'}
+        isOpen={menuOpen}
+        onOpenChange={() => {
+          setMenuStep('actions');
+          setMenuOpen(false);
+        }}
+        style={{ width: 200, margin: 1 }}
+        isNonModal
+        {...position}
+      >
+        <span tabIndex={-1} ref={ref}>
+          {menuStep === 'actions' && (
+            <TrackingToBudgetMenu
+              onTransfer={() => setMenuStep('transfer')}
+              onCover={() => setMenuStep('cover')}
+              onHoldBuffer={() => setMenuStep('buffer')}
+              onResetHoldBuffer={() => {
+                onBudgetAction(month, 'reset-hold');
+                setMenuOpen(false);
+              }}
+              month={month}
+              onBudgetAction={onBudgetAction}
+            />
+          )}
+          {menuStep === 'buffer' && (
+            <TrackingHoldMenu
+              onClose={() => setMenuOpen(false)}
+              onSubmit={amount => {
+                onBudgetAction(month, 'hold', { amount });
+              }}
+            />
+          )}
+          {menuStep === 'transfer' && (
+            <TrackingTransferMenu
+              initialAmount={availableValue ?? undefined}
+              onClose={() => setMenuOpen(false)}
+              onSubmit={(amount, categoryId) => {
+                onBudgetAction(month, 'transfer-available', {
+                  amount,
+                  category: categoryId,
+                });
+              }}
+            />
+          )}
+          {menuStep === 'cover' && (
+            <TrackingCoverMenu
+              showToBeBudgeted={false}
+              onClose={() => setMenuOpen(false)}
+              onSubmit={categoryId => {
+                onBudgetAction(month, 'cover-overbudgeted', {
+                  category: categoryId,
+                });
+              }}
+            />
+          )}
+        </span>
+      </Popover>
+    </>
+  );
+} 

--- a/packages/desktop-client/src/components/budget/tracking/budgetsummary/TrackingToBudgetAmount.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/budgetsummary/TrackingToBudgetAmount.tsx
@@ -1,0 +1,100 @@
+import React, { type CSSProperties, type MouseEventHandler } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Block } from '@actual-app/components/block';
+import { styles } from '@actual-app/components/styles';
+import { theme } from '@actual-app/components/theme';
+import { Tooltip } from '@actual-app/components/tooltip';
+import { View } from '@actual-app/components/view';
+import { css } from '@emotion/css';
+
+import { TrackingTotalsList } from './TrackingTotalsList';
+
+import { useTrackingSheetValue } from '@desktop-client/components/budget/tracking/TrackingBudgetComponents';
+import { PrivacyFilter } from '@desktop-client/components/PrivacyFilter';
+import { useFormat } from '@desktop-client/hooks/useFormat';
+import { trackingBudget } from '@desktop-client/spreadsheet/bindings';
+
+type TrackingToBudgetAmountProps = {
+  prevMonthName: string;
+  style?: CSSProperties;
+  amountStyle?: CSSProperties;
+  onClick: () => void;
+  onContextMenu?: MouseEventHandler;
+  isTotalsListTooltipDisabled?: boolean;
+};
+
+export function TrackingToBudgetAmount({
+  prevMonthName,
+  style,
+  amountStyle,
+  onClick,
+  isTotalsListTooltipDisabled = false,
+  onContextMenu,
+}: TrackingToBudgetAmountProps) {
+  const { t } = useTranslation();
+  const sheetValue = useTrackingSheetValue({
+    name: trackingBudget.toBudget,
+    value: 0,
+  });
+  const format = useFormat();
+  const availableValue = sheetValue;
+  if (typeof availableValue !== 'number' && availableValue !== null) {
+    throw new Error(
+      'Expected availableValue to be a number but got ' + availableValue,
+    );
+  }
+  const num = availableValue ?? 0;
+  const isNegative = num < 0;
+
+  return (
+    <View style={{ alignItems: 'center', ...style }}>
+      <Block>{isNegative ? t('Overbudgeted:') : t('To Budget:')}</Block>
+      <View>
+        <Tooltip
+          content={
+            <TrackingTotalsList
+              prevMonthName={prevMonthName}
+              style={{
+                padding: 7,
+              }}
+            />
+          }
+          placement="bottom"
+          offset={3}
+          triggerProps={{ isDisabled: isTotalsListTooltipDisabled }}
+        >
+          <PrivacyFilter
+            style={{
+              textAlign: 'center',
+            }}
+          >
+            <Block
+              onClick={onClick}
+              onContextMenu={onContextMenu}
+              className={css([
+                styles.veryLargeText,
+                {
+                  fontWeight: 400,
+                  userSelect: 'none',
+                  cursor: 'pointer',
+                  color: isNegative ? theme.errorText : theme.pageTextPositive,
+                  marginBottom: -1,
+                  borderBottom: '1px solid transparent',
+                  ':hover': {
+                    borderColor: isNegative
+                      ? theme.errorBorder
+                      : theme.pageTextPositive,
+                  },
+                },
+                amountStyle,
+              ])}
+            >
+              {format(num, 'financial')}
+            </Block>
+          </PrivacyFilter>
+        </Tooltip>
+      </View>
+    </View>
+  );
+} 

--- a/packages/desktop-client/src/components/budget/tracking/budgetsummary/TrackingToBudgetMenu.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/budgetsummary/TrackingToBudgetMenu.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Menu } from '@actual-app/components/menu';
+import { styles } from '@actual-app/components/styles';
+
+type TrackingToBudgetMenuProps = {
+  onTransfer: () => void;
+  onCover: () => void;
+  onHoldBuffer: () => void;
+  onResetHoldBuffer: () => void;
+  month: string;
+  onBudgetAction: (month: string, action: string, arg?: unknown) => void;
+};
+
+export function TrackingToBudgetMenu({
+  onTransfer,
+  onCover,
+  onHoldBuffer,
+  onResetHoldBuffer,
+  month,
+  onBudgetAction,
+}: TrackingToBudgetMenuProps) {
+  const { t } = useTranslation();
+
+  const onMenuSelect = (name: string) => {
+    switch (name) {
+      case 'transfer':
+        onTransfer();
+        break;
+      case 'cover':
+        onCover();
+        break;
+      case 'hold':
+        onHoldBuffer();
+        break;
+      case 'reset-hold':
+        onResetHoldBuffer();
+        break;
+      default:
+        throw new Error(`Unrecognized menu item: ${name}`);
+    }
+  };
+
+  return (
+    <Menu
+      onMenuSelect={onMenuSelect}
+      getItemStyle={() => ({
+        ...styles.menuItem,
+        fontSize: 14,
+      })}
+      items={[
+        {
+          name: 'transfer',
+          text: t('Transfer to another category'),
+        },
+        {
+          name: 'cover',
+          text: t('Cover overspending'),
+        },
+        {
+          name: 'hold',
+          text: t('Hold for next month'),
+        },
+        {
+          name: 'reset-hold',
+          text: t('Reset hold'),
+        },
+      ]}
+    />
+  );
+} 

--- a/packages/desktop-client/src/components/budget/tracking/budgetsummary/TrackingTotalsList.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/budgetsummary/TrackingTotalsList.tsx
@@ -1,0 +1,121 @@
+import React, { type CSSProperties } from 'react';
+import { Trans } from 'react-i18next';
+
+import { AlignedText } from '@actual-app/components/aligned-text';
+import { Block } from '@actual-app/components/block';
+import { styles } from '@actual-app/components/styles';
+import { Tooltip } from '@actual-app/components/tooltip';
+import { View } from '@actual-app/components/view';
+
+import { TrackingCellValue } from '@desktop-client/components/budget/tracking/TrackingBudgetComponents';
+import { CellValueText } from '@desktop-client/components/spreadsheet/CellValue';
+import { useFormat } from '@desktop-client/hooks/useFormat';
+import { trackingBudget } from '@desktop-client/spreadsheet/bindings';
+
+type TrackingTotalsListProps = {
+  prevMonthName: string;
+  style?: CSSProperties;
+};
+
+export function TrackingTotalsList({ prevMonthName, style }: TrackingTotalsListProps) {
+  const format = useFormat();
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        lineHeight: 1.5,
+        justifyContent: 'center',
+        ...styles.smallText,
+        ...style,
+      }}
+    >
+      <View
+        style={{
+          textAlign: 'right',
+          marginRight: 10,
+          minWidth: 50,
+        }}
+      >
+        <Tooltip
+          style={{ ...styles.tooltip, lineHeight: 1.5, padding: '6px 10px' }}
+          content={
+            <>
+              <AlignedText
+                left="Income:"
+                right={
+                  <TrackingCellValue
+                    binding={trackingBudget.totalIncome}
+                    type="financial"
+                  />
+                }
+              />
+              <AlignedText
+                left="From Last Month:"
+                right={
+                  <TrackingCellValue
+                    binding={trackingBudget.fromLastMonth}
+                    type="financial"
+                  />
+                }
+              />
+            </>
+          }
+          placement="bottom end"
+        >
+          <TrackingCellValue
+            binding={trackingBudget.availableFunds}
+            type="financial"
+          >
+            {props => <CellValueText {...props} style={{ fontWeight: 600 }} />}
+          </TrackingCellValue>
+        </Tooltip>
+
+        <TrackingCellValue
+          binding={trackingBudget.totalBudgetedExpense}
+          type="financial"
+        >
+          {props => (
+            <CellValueText
+              {...props}
+              style={{ fontWeight: 600 }}
+              formatter={(value, type) => {
+                const v = format(value, type);
+                return value > 0 ? '+' + v : value === 0 ? '-' + v : v;
+              }}
+            />
+          )}
+        </TrackingCellValue>
+
+        <TrackingCellValue
+          binding={trackingBudget.buffered}
+          type="financial"
+        >
+          {props => (
+            <CellValueText
+              {...props}
+              style={{ fontWeight: 600 }}
+              formatter={(value, type) => {
+                const v = format(Math.abs(value), type);
+                return value >= 0 ? '-' + v : '+' + v;
+              }}
+            />
+          )}
+        </TrackingCellValue>
+      </View>
+
+      <View>
+        <Block>
+          <Trans>Available funds</Trans>
+        </Block>
+
+        <Block>
+          <Trans>Budgeted</Trans>
+        </Block>
+
+        <Block>
+          <Trans>Buffered</Trans>
+        </Block>
+      </View>
+    </View>
+  );
+} 

--- a/packages/desktop-client/src/components/modals/TrackingBudgetSummaryModal.tsx
+++ b/packages/desktop-client/src/components/modals/TrackingBudgetSummaryModal.tsx
@@ -10,11 +10,14 @@ import * as monthUtils from 'loot-core/shared/months';
 import { ExpenseTotal } from '@desktop-client/components/budget/tracking/budgetsummary/ExpenseTotal';
 import { IncomeTotal } from '@desktop-client/components/budget/tracking/budgetsummary/IncomeTotal';
 import { Saved } from '@desktop-client/components/budget/tracking/budgetsummary/Saved';
+import { TrackingTotalsList } from '@desktop-client/components/budget/tracking/budgetsummary/TrackingTotalsList';
+import { TrackingToBudget } from '@desktop-client/components/budget/tracking/budgetsummary/TrackingToBudget';
 import {
   Modal,
   ModalCloseButton,
   ModalHeader,
 } from '@desktop-client/components/common/Modal';
+import { useLocale } from '@desktop-client/hooks/useLocale';
 import { SheetNameProvider } from '@desktop-client/hooks/useSheetName';
 import { type Modal as ModalType } from '@desktop-client/modals/modalsSlice';
 
@@ -27,6 +30,7 @@ export function TrackingBudgetSummaryModal({
   month,
 }: TrackingBudgetSummaryModalProps) {
   const { t } = useTranslation();
+  const locale = useLocale();
   const currentMonth = monthUtils.currentMonth();
   return (
     <Modal name="tracking-budget-summary">
@@ -37,6 +41,22 @@ export function TrackingBudgetSummaryModal({
             rightContent={<ModalCloseButton onPress={close} />}
           />
           <SheetNameProvider name={sheetForMonth(month)}>
+            <TrackingTotalsList
+              prevMonthName={monthUtils.format(monthUtils.prevMonth(month), 'MMM', locale)}
+              style={{
+                ...styles.mediumText,
+                marginBottom: 20,
+              }}
+            />
+            <TrackingToBudget
+              prevMonthName={monthUtils.format(monthUtils.prevMonth(month), 'MMM', locale)}
+              month={month}
+              onBudgetAction={() => {}}
+              style={{
+                ...styles.mediumText,
+                marginBottom: 20,
+              }}
+            />
             <Stack
               spacing={2}
               style={{

--- a/packages/desktop-client/src/spreadsheet/bindings.ts
+++ b/packages/desktop-client/src/spreadsheet/bindings.ts
@@ -187,6 +187,12 @@ export const envelopeBudget = {
 } satisfies BudgetType<'envelope-budget'>;
 
 export const trackingBudget = {
+  // Rollover balance fields
+  fromLastMonth: 'from-last-month',
+  availableFunds: 'available-funds',
+  toBudget: 'to-budget',
+  buffered: 'buffered',
+
   totalBudgetedExpense: 'total-budgeted',
   totalBudgetedIncome: 'total-budget-income',
   totalBudgetedSaved: 'total-saved',

--- a/packages/desktop-client/src/spreadsheet/index.ts
+++ b/packages/desktop-client/src/spreadsheet/index.ts
@@ -59,6 +59,10 @@ export type Spreadsheets = {
     'uncategorized-balance': number;
 
     // Tracking budget fields
+    'from-last-month': number;
+    'available-funds': number;
+    'to-budget': number;
+    buffered: number;
     'total-budgeted': number;
     'total-budget-income': number;
     'total-saved': number;

--- a/packages/loot-core/src/server/budget/app.ts
+++ b/packages/loot-core/src/server/budget/app.ts
@@ -221,6 +221,10 @@ async function trackingBudgetMonth({ month }: { month: string }) {
   }
 
   let values = [
+    value('from-last-month'),
+    value('available-funds'),
+    value('to-budget'),
+    value('buffered'),
     value('total-budgeted'),
     value('total-budget-income'),
     value('total-saved'),

--- a/packages/loot-core/src/server/budget/base.ts
+++ b/packages/loot-core/src/server/budget/base.ts
@@ -267,7 +267,7 @@ export async function createBudget(months) {
           sheetName,
         );
       } else {
-        report.createSummary(groups, sheetName);
+        report.createSummary(groups, sheetName, prevSheetName);
       }
 
       meta.createdMonths.add(month);

--- a/upcoming-release-notes/5318.md
+++ b/upcoming-release-notes/5318.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [your-github-username]
+---
+
+Add rollover balance functionality to tracking budget method. Tracking budgets now include "from-last-month", "available-funds", "to-budget", and "buffered" fields, making the tracking method more complete and consistent with envelope budgeting. 


### PR DESCRIPTION
This update introduces new fields for the tracking budget method, including "from-last-month", "available-funds", "to-budget", and "buffered". This is a deviation from current Actual mindset - as this update also introduces including estimated income to "To Budget: " in the tracking budget. Relevant UI components and calculations have been updated to reflect these changes.

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
