### PR TITLE
Implement pay period phases 1.2 and 1.3

### DIFF
--- a/packages/loot-core/migrations/1757000000000_add_pay_period_config.sql
+++ b/packages/loot-core/migrations/1757000000000_add_pay_period_config.sql
@@ -1,0 +1,16 @@
+-- Add pay period configuration table
+CREATE TABLE IF NOT EXISTS pay_period_config (
+  id TEXT PRIMARY KEY,
+  enabled INTEGER DEFAULT 0,
+  pay_frequency TEXT DEFAULT 'monthly',
+  start_date TEXT,
+  pay_day_of_week INTEGER,
+  pay_day_of_month INTEGER,
+  year_start INTEGER
+);
+
+-- Insert default configuration if not exists
+INSERT INTO pay_period_config (id, enabled, pay_frequency, start_date, year_start)
+SELECT 'default', 0, 'monthly', '2024-01-01', 2024
+WHERE NOT EXISTS (SELECT 1 FROM pay_period_config WHERE id = 'default');
+

--- a/packages/loot-core/src/server/db/types/index.ts
+++ b/packages/loot-core/src/server/db/types/index.ts
@@ -251,6 +251,16 @@ export type DbDashboard = {
   tombstone: 1 | 0;
 };
 
+export type DbPayPeriodConfig = {
+  id: string;
+  enabled: 1 | 0;
+  pay_frequency: string;
+  start_date: string;
+  pay_day_of_week?: number | null;
+  pay_day_of_month?: number | null;
+  year_start: number;
+};
+
 export type DbViewTransactionInternal = {
   id: DbTransaction['id'];
   is_parent: DbTransaction['isParent'];

--- a/packages/loot-core/src/types/prefs.ts
+++ b/packages/loot-core/src/types/prefs.ts
@@ -19,6 +19,10 @@ export type SyncedPrefs = Partial<
     | 'currencySymbolPosition'
     | 'currencySpaceBetweenAmountAndSymbol'
     | 'defaultCurrencyCode'
+    | 'payPeriodEnabled'
+    | 'payPeriodFrequency'
+    | 'payPeriodStartDate'
+    | 'payPeriodYearStart'
     | `side-nav.show-balance-history-${string}`
     | `show-balances-${string}`
     | `show-extra-balances-${string}`


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
Implements pay period phases 1.2 and 1.3 as described in the implementation plan.

This PR:
- **Phase 1.2:** Adds synced preference keys (`payPeriodEnabled`, `payPeriodFrequency`, `payPeriodStartDate`, `payPeriodYearStart`) to `prefs.ts` to store user-defined pay period settings.
- **Phase 1.3:** Introduces the `pay_period_config` database table via a new migration and defines its `DbPayPeriodConfig` type, including a default configuration row.

These changes establish the foundational data structures for the upcoming pay period feature.

---
<a href="https://cursor.com/background-agent?bcId=bc-4d2a2317-d8a3-4beb-99c7-c0b20804e9ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4d2a2317-d8a3-4beb-99c7-c0b20804e9ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

