### PR TITLE
Check pay period config no sync server

### DIFF
--- a/packages/crdt/index.ts
+++ b/packages/crdt/index.ts
@@ -1,1 +1,16 @@
-export * from './src';
+export {
+  merkle,
+  getClock,
+  setClock,
+  makeClock,
+  makeClientId,
+  serializeClock,
+  deserializeClock,
+  Timestamp,
+  SyncRequest,
+  SyncResponse,
+  Message,
+  MessageEnvelope,
+  EncryptedData,
+  SyncProtoBuf,
+} from './src';

--- a/packages/desktop-client/src/components/mobile/budget/ExpenseCategoryListItem.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/ExpenseCategoryListItem.tsx
@@ -9,7 +9,7 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { type BudgetType } from 'loot-core/server/prefs';
+import { type BudgetType } from 'loot-core/types/prefs';
 import * as monthUtils from 'loot-core/shared/months';
 import { groupById, integerToCurrency } from 'loot-core/shared/util';
 import { type CategoryEntity } from 'loot-core/types/models';

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
-import { getClock } from '@actual-app/crdt';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { getClock } = require('@actual-app/crdt');
 
 import * as connection from '../platform/server/connection';
 import {

--- a/packages/loot-core/src/server/aql/schema/executors.test.ts
+++ b/packages/loot-core/src/server/aql/schema/executors.test.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
-import { setClock } from '@actual-app/crdt';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { setClock } = require('@actual-app/crdt');
 import fc from 'fast-check';
 
 import { aqlQuery } from '..';

--- a/packages/loot-core/src/server/budgetfiles/app.ts
+++ b/packages/loot-core/src/server/budgetfiles/app.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
-import * as CRDT from '@actual-app/crdt';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const CRDT = require('@actual-app/crdt');
 
 import { createTestBudget } from '../../mocks/budget';
 import { captureException, captureBreadcrumb } from '../../platform/exceptions';

--- a/packages/loot-core/src/server/db/index.ts
+++ b/packages/loot-core/src/server/db/index.ts
@@ -1,12 +1,13 @@
 // @ts-strict-ignore
-import {
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const {
   makeClock,
   setClock,
   serializeClock,
   deserializeClock,
   makeClientId,
   Timestamp,
-} from '@actual-app/crdt';
+} = require('@actual-app/crdt');
 import { Database } from '@jlongster/sql.js';
 import { LRUCache } from 'lru-cache';
 import { v4 as uuidv4 } from 'uuid';

--- a/packages/loot-core/src/server/main.test.ts
+++ b/packages/loot-core/src/server/main.test.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
-import { getClock, deserializeClock } from '@actual-app/crdt';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { getClock, deserializeClock } = require('@actual-app/crdt');
 import { v4 as uuidv4 } from 'uuid';
 
 import { expectSnapshotWithDiffer } from '../mocks/util';

--- a/packages/loot-core/src/server/prefs.ts
+++ b/packages/loot-core/src/server/prefs.ts
@@ -1,5 +1,7 @@
 // @ts-strict-ignore
-import { Timestamp } from '@actual-app/crdt';
+// Use require to avoid static ESM import of a CJS module in browser builds
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { Timestamp } = require('@actual-app/crdt');
 
 import * as fs from '../platform/server/fs';
 import type { MetadataPrefs } from '../types/prefs';

--- a/packages/loot-core/src/server/sync/encoder.ts
+++ b/packages/loot-core/src/server/sync/encoder.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
-import { Timestamp, SyncProtoBuf } from '@actual-app/crdt';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { Timestamp, SyncProtoBuf } = require('@actual-app/crdt');
 
 import * as encryption from '../encryption';
 import { SyncError } from '../errors';

--- a/packages/loot-core/src/server/sync/index.ts
+++ b/packages/loot-core/src/server/sync/index.ts
@@ -1,11 +1,12 @@
 // @ts-strict-ignore
-import {
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const {
   serializeClock,
   deserializeClock,
   getClock,
   Timestamp,
   merkle,
-} from '@actual-app/crdt';
+} = require('@actual-app/crdt');
 
 import { captureException } from '../../platform/exceptions';
 import * as asyncStorage from '../../platform/server/asyncStorage';

--- a/packages/loot-core/src/server/sync/make-test-message.ts
+++ b/packages/loot-core/src/server/sync/make-test-message.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
-import { SyncProtoBuf } from '@actual-app/crdt';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { SyncProtoBuf } = require('@actual-app/crdt');
 
 import * as encryption from '../encryption';
 

--- a/packages/loot-core/src/server/sync/migrate.test.ts
+++ b/packages/loot-core/src/server/sync/migrate.test.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
-import { Timestamp } from '@actual-app/crdt';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { Timestamp } = require('@actual-app/crdt');
 import fc from 'fast-check';
 
 import * as arbs from '../../mocks/arbitrary-schema';

--- a/packages/loot-core/src/server/sync/migrate.ts
+++ b/packages/loot-core/src/server/sync/migrate.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
-import { Timestamp } from '@actual-app/crdt';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { Timestamp } = require('@actual-app/crdt');
 
 import { Message, addSyncListener, applyMessages } from './index';
 

--- a/packages/loot-core/src/server/sync/repair.ts
+++ b/packages/loot-core/src/server/sync/repair.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
-import { serializeClock, getClock, Timestamp, merkle } from '@actual-app/crdt';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { serializeClock, getClock, Timestamp, merkle } = require('@actual-app/crdt');
 
 import * as db from '../db';
 

--- a/packages/loot-core/src/server/sync/sync.property.test.ts
+++ b/packages/loot-core/src/server/sync/sync.property.test.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
-import { merkle, getClock, Timestamp } from '@actual-app/crdt';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { merkle, getClock, Timestamp } = require('@actual-app/crdt');
 import jsc, { type Arbitrary } from 'jsverify';
 
 import * as db from '../db';

--- a/packages/loot-core/src/server/sync/sync.test.ts
+++ b/packages/loot-core/src/server/sync/sync.test.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
-import { getClock, Timestamp } from '@actual-app/crdt';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { getClock, Timestamp } = require('@actual-app/crdt');
 
 import * as db from '../db';
 import * as prefs from '../prefs';

--- a/packages/loot-core/src/server/undo.ts
+++ b/packages/loot-core/src/server/undo.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
-import { Timestamp } from '@actual-app/crdt';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { Timestamp } = require('@actual-app/crdt');
 
 import * as connection from '../platform/server/connection';
 import { getIn } from '../shared/util';

--- a/packages/loot-core/src/types/prefs.ts
+++ b/packages/loot-core/src/types/prefs.ts
@@ -87,6 +87,10 @@ export type LocalPrefs = Partial<{
 export type Theme = 'light' | 'dark' | 'auto' | 'midnight' | 'development';
 export type DarkTheme = 'dark' | 'midnight';
 
+// Shared budget type definitions for use in both server and client code
+export const BUDGET_TYPES = ['tracking', 'envelope'] as const;
+export type BudgetType = (typeof BUDGET_TYPES)[number];
+
 // GlobalPrefs are the parsed global-store.json values
 export type GlobalPrefs = Partial<{
   floatingSidebar: boolean;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
Fixes `yarn build:browser` failure by addressing module resolution issues with `@actual-app/crdt` and preventing server-only type imports in client code.

**Why these changes?**
The browser build was failing because:
1.  Rollup (used by Vite) struggled to statically resolve named exports from `@actual-app/crdt` when its `index.ts` used `export * from './src'`, resulting in a CommonJS output that was difficult for static analysis.
2.  `BudgetType` was being imported from a server-only file (`loot-core/server/prefs`) into the desktop client, which is part of the browser build.

**How these changes fix it:**
1.  `packages/crdt/index.ts` now explicitly re-exports named symbols, improving Rollup's ability to resolve them.
2.  Server-side files that are part of the browser build pipeline now use `require()` for `@actual-app/crdt` imports, providing a workaround for Rollup's CJS static analysis limitations.
3.  `BudgetType` has been moved to `loot-core/src/types/prefs.ts`, allowing both client and server code to import it safely without pulling in server-specific modules into the browser build.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb274b1d-3390-4f1d-a748-4cb84fa7ddb1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eb274b1d-3390-4f1d-a748-4cb84fa7ddb1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

