### PR TITLE
[AI] Add fork-local CI that runs on GitHub-hosted runners

### DIFF
--- a/.github/workflows/personal-check.yml
+++ b/.github/workflows/personal-check.yml
@@ -90,6 +90,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          # check-migrations.ts compares against `origin/master`. Upstream gets
+          # away with the default depth-1 clone because their PRs target master,
+          # so the base tip is a parent of the PR merge commit and merge-base
+          # resolves inside the shallow graph. PRs here target `develop`, where
+          # master is unrelated in a shallow clone and `git merge-base
+          # origin/master HEAD` exits 1. Full history is the reliable fix.
+          fetch-depth: 0
       - name: Set up environment
         uses: ./.github/actions/setup
         with:

--- a/.github/workflows/personal-check.yml
+++ b/.github/workflows/personal-check.yml
@@ -1,0 +1,98 @@
+name: Personal - Checks
+
+# Fork-local quality gate.
+#
+# Upstream's check.yml requests `depot-*` runners, which belong to the
+# actualbudget org's Depot account and never get picked up on this fork - every
+# run sits in `queued` forever. This is the same set of checks on GitHub-hosted
+# runners, which are free and unlimited because this repository is public.
+#
+# Named `personal-*` so that syncing from upstream never conflicts with it.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up environment
+        uses: ./.github/actions/setup
+        with:
+          download-translations: 'false'
+      - name: Lint
+        run: yarn lint
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up environment
+        uses: ./.github/actions/setup
+        with:
+          download-translations: 'false'
+      - name: Typecheck
+        run: yarn typecheck
+
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up environment
+        uses: ./.github/actions/setup
+        with:
+          download-translations: 'false'
+      - name: Test
+        run: yarn test
+
+  constraints:
+    name: Constraints
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up environment
+        uses: ./.github/actions/setup
+        with:
+          download-translations: 'false'
+      - name: Check dependency version consistency
+        run: yarn constraints
+      - name: Check tsconfig project references are in sync
+        run: yarn check:tsconfig-references
+
+  migrations:
+    name: Migrations
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up environment
+        uses: ./.github/actions/setup
+        with:
+          download-translations: 'false'
+      - name: Check migrations
+        run: yarn workspace @actual-app/ci-actions tsx bin/check-migrations.ts

--- a/.github/workflows/personal-e2e.yml
+++ b/.github/workflows/personal-e2e.yml
@@ -1,0 +1,113 @@
+name: Personal - E2E
+
+# Fork-local Playwright run on GitHub-hosted runners.
+#
+# Revived from the abandoned `claude/github-action-docker-deploy-Y3scn` branch
+# and corrected: that version pinned the Playwright container to v1.59.1 while
+# `develop` is now on @playwright/test 1.61.1 - the container image and the
+# installed package must match or the run fails at startup.
+#
+# Deliberately no VRT job. The `*-snapshots/` baselines were captured on
+# upstream's Depot hardware; replaying them on ubuntu-latest produces permanent
+# false failures. Use `yarn vrt:docker` locally instead.
+#
+# Exposed via `workflow_call` so personal-pi-image.yml can gate publishing on it.
+
+on:
+  pull_request:
+    paths:
+      - 'packages/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - '.github/workflows/personal-e2e.yml'
+      - '!packages/sync-server/**' # Sync server changes don't affect E2E tests
+      - '!packages/api/**' # API changes don't affect E2E tests
+      - '!packages/ci-actions/**' # CI actions changes don't affect E2E tests
+      - '!packages/docs/**' # Docs changes don't affect E2E tests
+      - '!packages/eslint-plugin-actual/**' # Eslint plugin changes don't affect E2E tests
+  workflow_call:
+  workflow_dispatch:
+
+env:
+  GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
+
+jobs:
+  build-web:
+    name: Build web bundle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up environment
+        uses: ./.github/actions/setup
+        with:
+          download-translations: 'false'
+      - name: Build browser bundle
+        # REACT_APP_NETLIFY=true flips isNonProductionEnvironment() on in the
+        # bundle so the "Create test file" button (used by every e2e beforeEach
+        # via ConfigurationPage.createTestFile()) survives into a production
+        # build. Without it every test times out waiting for a button that was
+        # tree-shaken out.
+        env:
+          REACT_APP_NETLIFY: 'true'
+        run: yarn build:browser --skip-translations
+      - name: Upload build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: desktop-client-build
+          path: packages/desktop-client/build/
+          retention-days: 1
+          overwrite: true
+
+  functional:
+    name: Functional (shard ${{ matrix.shard }}/3)
+    runs-on: ubuntu-latest
+    needs: build-web
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    container:
+      image: mcr.microsoft.com/playwright:v1.61.1-jammy
+    env:
+      # Serve the prebuilt bundle via bin/serve-build.mjs (which sets the
+      # COOP/COEP headers SharedArrayBuffer needs) instead of booting Vite.
+      E2E_USE_BUILD: '1'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up environment
+        uses: ./.github/actions/setup
+        with:
+          download-translations: 'false'
+      - name: Trust the repository directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Download web build
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: desktop-client-build
+          path: packages/desktop-client/build/
+      - name: Run E2E tests
+        # --trace=retain-on-failure overrides playwright.config.ts's
+        # `trace: 'on-first-retry'`, which produces no trace when a test fails
+        # on its first attempt. Traces are the only practical way to debug a
+        # failure from an iPad: download the artifact and open it at
+        # https://trace.playwright.dev (fully client-side, works in Safari).
+        run: yarn e2e --shard=${{ matrix.shard }}/3 --trace=retain-on-failure
+      - name: Upload test results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ !cancelled() }}
+        with:
+          name: e2e-test-results-shard-${{ matrix.shard }}
+          path: packages/desktop-client/test-results/
+          retention-days: 14
+          overwrite: true

--- a/.github/workflows/personal-pi-image.yml
+++ b/.github/workflows/personal-pi-image.yml
@@ -1,0 +1,138 @@
+name: Personal - Pi image
+
+# Builds the sync-server image for rocket-services (Raspberry Pi 3 Model B) and
+# publishes it to GHCR.
+#
+# armv7 ONLY. The Pi runs 32-bit Ubuntu 22.04 on a BCM2837, so arm64 images
+# cannot run on it at all - see the architecture gate in rocket-pi-3b's
+# reference/capacity.md. Building extra platforms would only burn QEMU minutes.
+#
+# GHCR rather than Docker Hub: it authenticates with the built-in GITHUB_TOKEN,
+# so there are no registry secrets to create or rotate from an iPad.
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'packages/sync-server/**'
+      - 'packages/loot-core/**'
+      - 'packages/desktop-client/**'
+      - 'packages/crdt/**'
+      - 'yarn.lock'
+      - '.github/workflows/personal-pi-image.yml'
+  workflow_dispatch:
+    inputs:
+      skip_e2e:
+        description: 'Skip E2E and publish immediately (for iterating on the image build itself)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  # Deliberately not derived from github.workflow. A called reusable workflow
+  # sees the *caller's* github.workflow, so sharing that expression between
+  # this file and personal-e2e.yml would put the called job in the same group
+  # as the job waiting on it, and the run would deadlock.
+  group: personal-pi-image-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/actual-server
+
+jobs:
+  e2e:
+    name: E2E
+    if: ${{ !inputs.skip_e2e }}
+    uses: ./.github/workflows/personal-e2e.yml
+
+  publish:
+    name: Build and push (linux/arm/v7)
+    runs-on: ubuntu-latest
+    needs: e2e
+    # `needs` on a skipped job would skip this one too, so allow the
+    # skip_e2e escape hatch through explicitly.
+    if: ${{ always() && (needs.e2e.result == 'success' || needs.e2e.result == 'skipped') }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Set up environment
+        uses: ./.github/actions/setup
+
+      # Building the bundle on the runner rather than inside the Dockerfile is
+      # upstream's approach (docker-nightly.yml): it builds once for every
+      # target platform and avoids yarn running out of memory under emulation.
+      - name: Build server bundle
+        run: yarn build:server
+
+      # Smoke-test natively first. A native amd64 build takes a couple of
+      # minutes, while the emulated armv7 build takes 20-40; there is no reason
+      # to discover a broken Dockerfile at the end of the slow one.
+      - name: Build image natively for smoke test
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          push: false
+          load: true
+          file: packages/sync-server/docker/ubuntu.Dockerfile
+          tags: actual-server-smoketest
+
+      - name: Check that the image boots
+        timeout-minutes: 2
+        run: |
+          docker run --detach --network=host --name smoketest actual-server-smoketest
+          HEALTHCMD=$(yq -r '.services.actual_server.healthcheck.test[1]' packages/sync-server/docker-compose.yml)
+          until docker exec smoketest sh -c "$HEALTHCMD"; do sleep 1; done
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: docker logs smoketest || true
+
+      # Reuses the layer cache from the smoke-test build where it can. The
+      # armv7 stage still compiles better-sqlite3 and bcrypt under QEMU, which
+      # is the slow part; type=gha caching keeps repeat builds tolerable.
+      - name: Build and push armv7 image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          push: true
+          file: packages/sync-server/docker/ubuntu.Dockerfile
+          platforms: linux/arm/v7
+          tags: |
+            ${{ env.IMAGE }}:pi
+            ${{ env.IMAGE }}:pi-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          {
+            echo "### Pi image published"
+            echo
+            echo '```'
+            echo "docker pull ${IMAGE}:pi"
+            echo '```'
+            echo
+            echo "Rollback tag: \`${IMAGE}:pi-${SHA}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/actual-server
+          SHA: ${{ github.sha }}

--- a/.github/workflows/personal-preview.yml
+++ b/.github/workflows/personal-preview.yml
@@ -1,0 +1,82 @@
+name: Personal - Preview
+
+# Optional, on-demand preview deploy. Never runs automatically.
+#
+# Why Cloudflare Pages and not GitHub Pages: packages/desktop-client/public/_headers
+# sets Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy, which Actual
+# needs for SharedArrayBuffer. GitHub Pages cannot send custom headers, so a
+# Pages deploy boots straight into the "Actual requires SharedArrayBuffer" fatal
+# error (see FatalError.tsx). Cloudflare Pages reads that same _headers file
+# natively, so no application change is needed.
+#
+# Inert until you set the CLOUDFLARE_ENABLED repository variable to 'true' and
+# add the CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID secrets. Day to day,
+# Playwright traces from personal-e2e.yml are the primary debugging surface.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag or SHA to preview'
+        type: string
+        default: develop
+      project_name:
+        description: 'Cloudflare Pages project name'
+        type: string
+        default: actual-preview
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: Deploy preview
+    if: vars.CLOUDFLARE_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Set up environment
+        uses: ./.github/actions/setup
+        with:
+          download-translations: 'false'
+
+      - name: Build browser bundle
+        # Matches the e2e build so the preview behaves like what CI exercised.
+        env:
+          REACT_APP_NETLIFY: 'true'
+        run: yarn build:browser --skip-translations
+
+      # Cheap guard against a silent regression: if Vite ever stops copying
+      # public/_headers into the build, the deploy still succeeds but the app
+      # dies on SharedArrayBuffer. Better to fail here with a clear reason.
+      - name: Verify COOP/COEP headers are in the build output
+        run: |
+          HEADERS=packages/desktop-client/build/_headers
+          if [ ! -f "$HEADERS" ]; then
+            echo "::error::_headers is missing from the build output; the preview would fail on SharedArrayBuffer."
+            exit 1
+          fi
+          grep -q 'Cross-Origin-Embedder-Policy' "$HEADERS" || {
+            echo "::error::_headers is present but has no COEP directive."
+            exit 1
+          }
+
+      - name: Deploy to Cloudflare Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT_NAME: ${{ inputs.project_name }}
+          DEPLOY_REF: ${{ inputs.ref }}
+        run: |
+          npx --yes wrangler@4 pages deploy packages/desktop-client/build \
+            --project-name="$PROJECT_NAME" \
+            --branch="$DEPLOY_REF" \
+            --commit-dirty=true


### PR DESCRIPTION
Upstream's workflows request `depot-*` runners belonging to the actualbudget org, so on this fork every run sits in `queued` forever - the last 30 runs contain zero successes. These four `personal-*` workflows re-implement the checks that matter on `ubuntu-latest`, which is free and unlimited here because the repository is public.

- personal-check: lint, typecheck, unit tests, constraints, migrations
- personal-e2e: 3-shard Playwright, exposed via workflow_call. Revived from the abandoned claude/github-action-docker-deploy-Y3scn branch, with the container image corrected to v1.61.1 to match @playwright/test on develop, and --trace=retain-on-failure so a first-attempt failure still leaves a trace to open at trace.playwright.dev.
- personal-pi-image: gates on E2E, smoke-tests a native build, then pushes a linux/arm/v7 image to GHCR for the Raspberry Pi 3B (32-bit, so arm64 is not a valid target).
- personal-preview: opt-in Cloudflare Pages deploy, inert until the CLOUDFLARE_ENABLED variable is set.

The `personal-` prefix keeps these from ever conflicting with upstream syncs.


Claude-Session: https://claude.ai/code/session_01V1HSEvdm7ykHkwC58P1tsr

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
