### PR TITLE
[AI] Add a lint rule against building dates from month IDs

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -400,6 +400,29 @@
     },
     {
       "files": [
+        "packages/loot-core/src/server/budget/**/*",
+        "packages/loot-core/src/shared/**/*",
+        "packages/desktop-client/src/components/budget/**/*",
+        "packages/desktop-client/src/components/mobile/budget/**/*",
+        "packages/desktop-client/src/components/modals/**/*",
+        "packages/desktop-client/src/hooks/**/*"
+      ],
+      "rules": {
+        "actual/no-month-date-concat": "error"
+      }
+    },
+    {
+      "files": [
+        "packages/loot-core/src/shared/months.ts",
+        "packages/loot-core/src/shared/pay-periods.ts",
+        "**/*.test.{js,ts,jsx,tsx}"
+      ],
+      "rules": {
+        "actual/no-month-date-concat": "off"
+      }
+    },
+    {
+      "files": [
         "packages/api/migrations/*",
         "packages/loot-core/migrations/*",
         "packages/sync-server/src/app-gocardless/banks/*.ts",

--- a/packages/component-library/src/ModeButton.tsx
+++ b/packages/component-library/src/ModeButton.tsx
@@ -11,6 +11,7 @@ type ModeButtonProps = {
   children: ReactNode;
   style?: CSSProperties;
   onSelect: () => void;
+  isDisabled?: boolean;
 };
 
 export function ModeButton({
@@ -18,10 +19,12 @@ export function ModeButton({
   children,
   style,
   onSelect,
+  isDisabled,
 }: ModeButtonProps) {
   return (
     <Button
       variant="bare"
+      isDisabled={isDisabled}
       className={css({
         padding: '5px 10px',
         backgroundColor: theme.menuBackground,

--- a/packages/desktop-client/e2e/page-models/budget-page.ts
+++ b/packages/desktop-client/e2e/page-models/budget-page.ts
@@ -19,7 +19,9 @@ export class BudgetPage {
     this.budgetTable = page.getByTestId('budget-table');
     this.budgetTableTotals = this.budgetTable.getByTestId('budget-totals');
     this.selectedMonthButton = page.getByTestId('selected-budget-month');
-    this.nextMonthButton = page.getByTitle('Next month');
+    // MonthPicker titles this control 'Next period' while pay periods are
+    // active, so match either name.
+    this.nextMonthButton = page.getByTitle(/^Next (month|period)$/);
     this.budgetTableScrollContainer = page.getByTestId(
       'budget-table-scroll-container',
     );

--- a/packages/desktop-client/e2e/page-models/mobile-budget-page.ts
+++ b/packages/desktop-client/e2e/page-models/mobile-budget-page.ts
@@ -101,11 +101,17 @@ export class MobileBudgetPage {
   }
 
   async determineBudgetType() {
-    return (await this.#getButtonForEnvelopeBudgetSummary({
-      throwIfNotFound: false,
-    })) !== null
-      ? 'Envelope'
-      : 'Tracking';
+    // Wait for either mode's summary button, then report which one is
+    // present. Waiting only for the envelope button and treating its
+    // absence as "Tracking" hangs on a real tracking budget: with no
+    // actionTimeout configured, the wait for the never-appearing envelope
+    // button runs until the test times out.
+    const envelopeButton = this.toBudgetButton.or(this.overbudgetedButton);
+    const trackingButton = this.savedButton
+      .or(this.projectedSavingsButton)
+      .or(this.overspentButton);
+    await envelopeButton.or(trackingButton).first().waitFor();
+    return (await envelopeButton.count()) > 0 ? 'Envelope' : 'Tracking';
   }
 
   async waitFor(...options: Parameters<Locator['waitFor']>) {

--- a/packages/desktop-client/e2e/page-models/mobile-budget-page.ts
+++ b/packages/desktop-client/e2e/page-models/mobile-budget-page.ts
@@ -38,12 +38,16 @@ export class MobileBudgetPage {
     // Page header locators
 
     this.heading = page.getByRole('heading');
+    // The header renames these per budgeting mode — 'Previous month' becomes
+    // 'Previous period' while pay periods are active (see
+    // mobile/budget/BudgetPage.tsx) — so match either. Without this the page
+    // model silently finds nothing in pay period mode.
     this.previousMonthButton = this.heading.getByRole('button', {
-      name: 'Previous month',
+      name: /^Previous (month|period)$/,
     });
     this.selectedBudgetMonthButton = this.heading.locator('button[data-month]');
     this.nextMonthButton = this.heading.getByRole('button', {
-      name: 'Next month',
+      name: /^Next (month|period)$/,
     });
     this.budgetPageMenuButton = page.getByRole('button', {
       name: 'Budget page menu',

--- a/packages/desktop-client/e2e/pay-period-helpers.ts
+++ b/packages/desktop-client/e2e/pay-period-helpers.ts
@@ -1,0 +1,76 @@
+import { setPayPeriodConfig } from '@actual-app/core/shared/pay-period-config';
+import { expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+/**
+ * Shared setup for the pay period suites (desktop and mobile).
+ *
+ * Under Playwright the current date is pinned to 2017-01-01, so a biweekly
+ * cadence anchored on 2017-01-01 makes every period deterministic:
+ * '2017-13' = Jan 1 - Jan 14 is the current pay period.
+ */
+export const PAY_PERIOD_START_DATE = '2017-01-01';
+export const PAY_PERIOD_FREQUENCY_LABEL = 'Every 2 weeks';
+export const CURRENT_PERIOD = '2017-13';
+export const CURRENT_PERIOD_LABEL = 'Jan 1 - Jan 14';
+export const NEXT_PERIOD = '2017-14';
+export const NEXT_PERIOD_LABEL = 'Jan 15 - Jan 28';
+export const PREVIOUS_PERIOD = '2016-38';
+export const PREVIOUS_PERIOD_LABEL = 'Dec 18 - Dec 31';
+export const CURRENT_CALENDAR_MONTH = '2017-01';
+
+export function getPayPeriodCheckbox(page: Page) {
+  return page.getByRole('checkbox', { name: 'Budget by pay period' });
+}
+
+export async function selectPayFrequency(page: Page, frequencyLabel: string) {
+  // The pay period section only mounts once the experimental flag has
+  // landed; wait for it rather than racing the settings re-render.
+  const frequencySelect = page.locator('#pay-period-frequency');
+  await frequencySelect.waitFor({ state: 'visible', timeout: 15000 });
+  await frequencySelect.click();
+  await page.getByRole('button', { name: frequencyLabel, exact: true }).click();
+}
+
+/**
+ * Toggles the "Budget by pay period" checkbox into the desired state.
+ *
+ * The control is disabled for as long as the save is in flight — the server
+ * cold-builds every budget column for the new mode before the pref save
+ * resolves — so one click is enough; just wait for it to come back.
+ */
+export async function togglePayPeriods(page: Page, enabled: boolean) {
+  const checkbox = getPayPeriodCheckbox(page);
+  await expect(checkbox).toBeEnabled();
+
+  if ((await checkbox.isChecked()) === enabled) {
+    return;
+  }
+
+  await checkbox.click();
+  await expect(checkbox).toBeChecked({ checked: enabled, timeout: 60000 });
+  await expect(checkbox).toBeEnabled({ timeout: 60000 });
+}
+
+/**
+ * Configure a biweekly pay period cadence and turn on pay period budgeting.
+ * Assumes the pay period settings section is already visible (i.e. the 'Pay
+ * periods' feature flag is enabled).
+ *
+ * Also activates the same cadence in the *test* process, so that helpers
+ * which call `monthUtils` here — rather than driving the UI — resolve period
+ * IDs instead of throwing `no pay period configuration is active`. Both come
+ * from the constants above, so the test's view of the cadence cannot drift
+ * from what the app was configured with. Pair with
+ * `resetPayPeriodConfigForTesting()` in an afterEach.
+ */
+export async function configureAndEnablePayPeriods(page: Page) {
+  await selectPayFrequency(page, PAY_PERIOD_FREQUENCY_LABEL);
+  await page.locator('#pay-period-start-date').fill(PAY_PERIOD_START_DATE);
+  await togglePayPeriods(page, true);
+
+  setPayPeriodConfig({
+    payFrequency: 'biweekly',
+    startDate: PAY_PERIOD_START_DATE,
+  });
+}

--- a/packages/desktop-client/e2e/pay-period-helpers.ts
+++ b/packages/desktop-client/e2e/pay-period-helpers.ts
@@ -66,7 +66,11 @@ export async function togglePayPeriods(page: Page, enabled: boolean) {
  */
 export async function configureAndEnablePayPeriods(page: Page) {
   await selectPayFrequency(page, PAY_PERIOD_FREQUENCY_LABEL);
-  await page.locator('#pay-period-start-date').fill(PAY_PERIOD_START_DATE);
+  const startDateInput = page.locator('#pay-period-start-date');
+  await startDateInput.fill(PAY_PERIOD_START_DATE);
+  // The date field commits on blur/Enter rather than per keystroke, so the
+  // fill alone doesn't save the pref.
+  await startDateInput.press('Enter');
   await togglePayPeriods(page, true);
 
   setPayPeriodConfig({

--- a/packages/desktop-client/e2e/pay-periods.mobile.test.ts
+++ b/packages/desktop-client/e2e/pay-periods.mobile.test.ts
@@ -36,17 +36,13 @@ async function configureAndEnablePayPeriods(page: Page) {
     name: 'Budget by pay period',
   });
   await expect(checkbox).toBeEnabled();
-  // Clicks on the settings checkboxes can race a re-render and get lost,
-  // but a click that did land resolves slowly — the synced pref (and so
-  // the checkbox) only updates once the server has rebuilt every budget
-  // sheet for the new mode. So lost clicks are retried, with an inner
-  // wait long enough to never double-click during an in-flight save.
-  await expect(async () => {
-    if (!(await checkbox.isChecked())) {
-      await checkbox.click();
-    }
-    await expect(checkbox).toBeChecked({ timeout: 20000 });
-  }).toPass({ timeout: 120000 });
+
+  // The control is disabled for as long as the save is in flight — the
+  // server cold-builds every budget column for the new mode before the
+  // pref save resolves — so one click is enough; wait for it to come back.
+  await checkbox.click();
+  await expect(checkbox).toBeChecked({ timeout: 60000 });
+  await expect(checkbox).toBeEnabled({ timeout: 60000 });
 }
 
 async function goToAdjacentPeriod(

--- a/packages/desktop-client/e2e/pay-periods.mobile.test.ts
+++ b/packages/desktop-client/e2e/pay-periods.mobile.test.ts
@@ -1,3 +1,4 @@
+import { resetPayPeriodConfigForTesting } from '@actual-app/core/shared/pay-period-config';
 import { amountToCurrency } from '@actual-app/core/shared/util';
 import type { Page } from '@playwright/test';
 
@@ -5,61 +6,13 @@ import { expect, test } from './fixtures';
 import { ConfigurationPage } from './page-models/configuration-page';
 import type { MobileBudgetPage } from './page-models/mobile-budget-page';
 import { MobileNavigation } from './page-models/mobile-navigation';
-
-// Under Playwright the current date is pinned to 2017-01-01, so a biweekly
-// cadence anchored on 2017-01-01 makes every period deterministic:
-// '2017-13' = Jan 1 - Jan 14 is the current pay period.
-const PAY_PERIOD_START_DATE = '2017-01-01';
-const PAY_PERIOD_FREQUENCY_LABEL = 'Every 2 weeks';
-const CURRENT_PERIOD = '2017-13';
-const CURRENT_PERIOD_LABEL = 'Jan 1 - Jan 14';
-const PREVIOUS_PERIOD = '2016-38';
-const PREVIOUS_PERIOD_LABEL = 'Dec 18 - Dec 31';
-
-/**
- * Configure a biweekly pay period cadence and turn on pay period
- * budgeting. Assumes the settings page is open and the 'Pay periods'
- * feature flag is enabled.
- */
-async function configureAndEnablePayPeriods(page: Page) {
-  // The pay period section only mounts once the experimental flag has
-  // landed; wait for it rather than racing the settings re-render.
-  const frequencySelect = page.locator('#pay-period-frequency');
-  await frequencySelect.waitFor({ state: 'visible', timeout: 15000 });
-  await frequencySelect.click();
-  await page
-    .getByRole('button', { name: PAY_PERIOD_FREQUENCY_LABEL, exact: true })
-    .click();
-  await page.locator('#pay-period-start-date').fill(PAY_PERIOD_START_DATE);
-
-  const checkbox = page.getByRole('checkbox', {
-    name: 'Budget by pay period',
-  });
-  await expect(checkbox).toBeEnabled();
-
-  // The control is disabled for as long as the save is in flight — the
-  // server cold-builds every budget column for the new mode before the
-  // pref save resolves — so one click is enough; wait for it to come back.
-  await checkbox.click();
-  await expect(checkbox).toBeChecked({ timeout: 60000 });
-  await expect(checkbox).toBeEnabled({ timeout: 60000 });
-}
-
-async function goToAdjacentPeriod(
-  budgetPage: MobileBudgetPage,
-  direction: 'Previous period' | 'Next period',
-) {
-  const currentMonth = await budgetPage.getSelectedMonth();
-
-  await budgetPage.heading.getByRole('button', { name: direction }).click();
-
-  await expect(
-    budgetPage.heading.locator('[data-month]'),
-    `Failed to navigate to the ${direction.toLowerCase()}.`,
-  ).not.toHaveAttribute('data-month', currentMonth);
-
-  return budgetPage.getSelectedMonth();
-}
+import {
+  configureAndEnablePayPeriods,
+  CURRENT_PERIOD,
+  CURRENT_PERIOD_LABEL,
+  PREVIOUS_PERIOD,
+  PREVIOUS_PERIOD_LABEL,
+} from './pay-period-helpers';
 
 test.describe('Mobile Budget in pay period mode', () => {
   let page: Page;
@@ -110,6 +63,7 @@ test.describe('Mobile Budget in pay period mode', () => {
   });
 
   test.afterEach(async () => {
+    resetPayPeriodConfigForTesting();
     await page.close();
   });
 
@@ -124,16 +78,13 @@ test.describe('Mobile Budget in pay period mode', () => {
 
   test('previous and next period buttons navigate one period at a time', async () => {
     // One period back crosses the year boundary into 2016's last period.
-    const previousPeriod = await goToAdjacentPeriod(
-      budgetPage,
-      'Previous period',
-    );
+    const previousPeriod = await budgetPage.goToPreviousMonth();
     expect(previousPeriod).toBe(PREVIOUS_PERIOD);
     await expect(budgetPage.selectedBudgetMonthButton).toHaveText(
       PREVIOUS_PERIOD_LABEL,
     );
 
-    const nextPeriod = await goToAdjacentPeriod(budgetPage, 'Next period');
+    const nextPeriod = await budgetPage.goToNextMonth();
     expect(nextPeriod).toBe(CURRENT_PERIOD);
     await expect(budgetPage.selectedBudgetMonthButton).toHaveText(
       CURRENT_PERIOD_LABEL,
@@ -158,13 +109,13 @@ test.describe('Mobile Budget in pay period mode', () => {
     const categoryName = await budgetPage.getCategoryNameForRow(3);
 
     // Budget an amount in the previous period (crosses the year boundary).
-    await goToAdjacentPeriod(budgetPage, 'Previous period');
+    await budgetPage.goToPreviousMonth();
 
     const budgetAmount = 100;
     const budgetMenuModal = await budgetPage.openBudgetMenu(categoryName);
     await budgetMenuModal.setBudgetAmount(`${budgetAmount}00`);
 
-    await goToAdjacentPeriod(budgetPage, 'Next period');
+    await budgetPage.goToNextMonth();
 
     const currentPeriodBudgetMenuModal =
       await budgetPage.openBudgetMenu(categoryName);
@@ -176,6 +127,69 @@ test.describe('Mobile Budget in pay period mode', () => {
     await expect(budgetedButton).toHaveText(amountToCurrency(budgetAmount));
   });
 
+  // Mirrors `applies budget template` in budget.mobile.test.ts, but against
+  // a pay period column. The template engine resolves its windows through
+  // budget columns now (see shared/months.ts budgetColumn* helpers), and
+  // this is the end-to-end check that a template applied in a period lands
+  // the right amount.
+  test('applies a budget template within the period', async () => {
+    const settingsPage = await navigation.goToSettingsPage();
+    await settingsPage.enableExperimentalFeature('Goal templates');
+    const uiToggle = page.getByRole('checkbox', {
+      name: 'Budget automations UI',
+    });
+    await uiToggle.waitFor({ state: 'visible' });
+    if (!(await uiToggle.isChecked())) {
+      await uiToggle.click();
+    }
+
+    budgetPage = await navigation.goToBudgetPage();
+    await expect(budgetPage.selectedBudgetMonthButton).toHaveText(
+      CURRENT_PERIOD_LABEL,
+    );
+
+    const categoryName = await budgetPage.getCategoryNameForRow(1);
+    const amountToTemplate = 123;
+
+    const categoryMenuModal = await budgetPage.openCategoryMenu(categoryName);
+    const automationsModal = await categoryMenuModal.editAutomations();
+    await automationsModal
+      .getByRole('button', { name: 'Add an automation' })
+      .click();
+    const amountField = automationsModal.locator('#amount-field');
+    await amountField.fill(String(amountToTemplate));
+    await amountField.press('Enter');
+    await automationsModal
+      .getByRole('spinbutton', { name: 'Priority' })
+      .fill('0');
+    await automationsModal
+      .getByRole('button', { name: 'Back', exact: true })
+      .click();
+    await automationsModal
+      .getByRole('button', { name: 'Save', exact: true })
+      .click();
+    await expect(automationsModal).toBeHidden();
+
+    const budgetedButton = await budgetPage.getButtonForBudgeted(categoryName);
+    // Starts at 0.00; the assertion below is what proves the template
+    // engine produced a value for this *period* column.
+    await expect(budgetedButton).toHaveText(amountToCurrency(0));
+
+    const budgetMenuModal = await budgetPage.openBudgetMenu(categoryName);
+    await budgetMenuModal.applyBudgetTemplate();
+    await budgetMenuModal.close();
+
+    await expect(budgetedButton).toHaveText(amountToCurrency(amountToTemplate));
+  });
+
+  test('the month menu names the period, not a calendar month', async () => {
+    await budgetPage.openMonthMenu();
+
+    const modal = page.getByRole('dialog', { name: 'Modal dialog' });
+    await expect(modal).toBeVisible();
+    await expect(modal).toContainText(CURRENT_PERIOD_LABEL);
+  });
+
   test("opens a category's transactions filtered to the pay period", async () => {
     const categoryName = await budgetPage.getCategoryNameForRow(0);
     const accountPage = await budgetPage.openSpentPage(categoryName);
@@ -183,5 +197,80 @@ test.describe('Mobile Budget in pay period mode', () => {
     await expect(accountPage.heading).toContainText(categoryName);
     await expect(accountPage.heading).toContainText(CURRENT_PERIOD_LABEL);
     await expect(accountPage.transactionList).toBeVisible();
+  });
+});
+
+test.describe('Mobile Tracking budget in pay period mode', () => {
+  let page: Page;
+  let navigation: MobileNavigation;
+  let configurationPage: ConfigurationPage;
+  let budgetPage: MobileBudgetPage;
+  let previousGlobalIsTesting: boolean;
+
+  test.beforeAll(() => {
+    // TODO: Hack, properly mock the currentMonth function
+    previousGlobalIsTesting = global.IS_TESTING;
+    global.IS_TESTING = true;
+  });
+
+  test.afterAll(() => {
+    // TODO: Hack, properly mock the currentMonth function
+    global.IS_TESTING = previousGlobalIsTesting;
+  });
+
+  test.beforeEach(async ({ browser }) => {
+    test.setTimeout(180_000);
+
+    page = await browser.newPage();
+    navigation = new MobileNavigation(page);
+    configurationPage = new ConfigurationPage(page);
+
+    await page.setViewportSize({ width: 350, height: 600 });
+    await page.goto('/');
+    await configurationPage.createTestFile();
+
+    const settingsPage = await navigation.goToSettingsPage();
+    await settingsPage.useBudgetType('Tracking');
+    await settingsPage.enableExperimentalFeature('Pay periods');
+    await configureAndEnablePayPeriods(page);
+
+    budgetPage = await navigation.goToBudgetPage();
+    await expect(budgetPage.heading.locator('[data-month]')).toHaveAttribute(
+      'data-month',
+      CURRENT_PERIOD,
+      { timeout: 30000 },
+    );
+  });
+
+  test.afterEach(async () => {
+    resetPayPeriodConfigForTesting();
+    await page.close();
+  });
+
+  // The tracking budget reads its cells through `trackingBudgetMonth`, a
+  // different server handler from the envelope budget's — this is the only
+  // coverage that exercises it against pay period sheets.
+  test('renders the tracking budget for the current pay period', async () => {
+    await expect(budgetPage.selectedBudgetMonthButton).toHaveText(
+      CURRENT_PERIOD_LABEL,
+    );
+    await expect(budgetPage.categoryNames.first()).toBeVisible();
+  });
+
+  test('shows the savings summary for the period', async () => {
+    const summaryButton = budgetPage.page.getByRole('button', {
+      name: /Saved|Projected savings|Overspent/,
+    });
+    await expect(summaryButton.first()).toBeVisible();
+  });
+
+  test('updates a budgeted amount in a pay period', async () => {
+    const categoryName = await budgetPage.getCategoryNameForRow(0);
+    const budgetMenuModal = await budgetPage.openBudgetMenu(categoryName);
+
+    await budgetMenuModal.setBudgetAmount('12300');
+
+    const budgetedButton = await budgetPage.getButtonForBudgeted(categoryName);
+    await expect(budgetedButton).toHaveText(amountToCurrency(123));
   });
 });

--- a/packages/desktop-client/e2e/pay-periods.mobile.test.ts
+++ b/packages/desktop-client/e2e/pay-periods.mobile.test.ts
@@ -128,11 +128,13 @@ test.describe('Mobile Budget in pay period mode', () => {
   });
 
   // Mirrors `applies budget template` in budget.mobile.test.ts, but against
-  // a pay period column. The template engine resolves its windows through
-  // budget columns now (see shared/months.ts budgetColumn* helpers), and
-  // this is the end-to-end check that a template applied in a period lands
-  // the right amount.
-  test('applies a budget template within the period', async () => {
+  // a pay period column. The automation created here is a fixed-amount
+  // template, which is deliberately per-column (an allocation per
+  // paycheck), so this checks the apply pipeline reaches the period sheet —
+  // NOT the column-vs-month arithmetic of by/spend/periodic templates,
+  // which is covered by the loot-core suites
+  // (goal-template.pay-periods.test.ts and friends).
+  test('applying a fixed-amount automation lands in the period column', async () => {
     const settingsPage = await navigation.goToSettingsPage();
     await settingsPage.enableExperimentalFeature('Goal templates');
     const uiToggle = page.getByRole('checkbox', {
@@ -196,7 +198,18 @@ test.describe('Mobile Budget in pay period mode', () => {
 
     await expect(accountPage.heading).toContainText(categoryName);
     await expect(accountPage.heading).toContainText(CURRENT_PERIOD_LABEL);
-    await expect(accountPage.transactionList).toBeVisible();
+
+    // The heading is rendered from the month ID, so it alone can't prove
+    // the query was filtered. The list groups transactions under date
+    // headers ('January 05, 2017'): a non-empty list whose headers all fall
+    // inside Jan 1-14 is what shows the period's day-range filter was
+    // actually applied — the test file has spending in December 2016 and
+    // late January that an unfiltered query would surface.
+    await expect(accountPage.transactions.first()).toBeVisible();
+    await expect(accountPage.transactionList).not.toContainText('2016');
+    await expect(accountPage.transactionList).not.toContainText(
+      /January (1[5-9]|2\d|3[01]), 2017/,
+    );
   });
 });
 
@@ -249,27 +262,29 @@ test.describe('Mobile Tracking budget in pay period mode', () => {
 
   // The tracking budget reads its cells through `trackingBudgetMonth`, a
   // different server handler from the envelope budget's — this is the only
-  // coverage that exercises it against pay period sheets.
+  // coverage that exercises it against pay period sheets. `useBudgetType`
+  // is a best-effort click, so each test first proves the switch actually
+  // happened; without that the whole suite could silently run against the
+  // envelope budget and still pass.
   test('renders the tracking budget for the current pay period', async () => {
+    expect(await budgetPage.determineBudgetType()).toBe('Tracking');
     await expect(budgetPage.selectedBudgetMonthButton).toHaveText(
       CURRENT_PERIOD_LABEL,
     );
     await expect(budgetPage.categoryNames.first()).toBeVisible();
   });
 
-  test('shows the savings summary for the period', async () => {
-    const summaryButton = budgetPage.page.getByRole('button', {
-      name: /Saved|Projected savings|Overspent/,
-    });
-    await expect(summaryButton.first()).toBeVisible();
-  });
-
   test('updates a budgeted amount in a pay period', async () => {
+    expect(await budgetPage.determineBudgetType()).toBe('Tracking');
+
     const categoryName = await budgetPage.getCategoryNameForRow(0);
     const budgetMenuModal = await budgetPage.openBudgetMenu(categoryName);
 
     await budgetMenuModal.setBudgetAmount('12300');
 
+    // The budgeted cell is bound to the tracking sheet's `budget-<id>` for
+    // this period column, so the value coming back proves the write and the
+    // read both went through `trackingBudgetMonth` sheets.
     const budgetedButton = await budgetPage.getButtonForBudgeted(categoryName);
     await expect(budgetedButton).toHaveText(amountToCurrency(123));
   });

--- a/packages/desktop-client/e2e/pay-periods.test.ts
+++ b/packages/desktop-client/e2e/pay-periods.test.ts
@@ -1,66 +1,25 @@
+import { resetPayPeriodConfigForTesting } from '@actual-app/core/shared/pay-period-config';
 import type { Page } from '@playwright/test';
 
 import { expect, test } from './fixtures';
 import type { BudgetPage } from './page-models/budget-page';
 import { ConfigurationPage } from './page-models/configuration-page';
 import { Navigation } from './page-models/navigation';
-
-// Under Playwright the current date is pinned to 2017-01-01, so a biweekly
-// cadence anchored on 2017-01-01 makes every period deterministic:
-// '2017-13' = Jan 1 - Jan 14 is the current pay period.
-const PAY_PERIOD_START_DATE = '2017-01-01';
-const PAY_PERIOD_FREQUENCY_LABEL = 'Every 2 weeks';
-const CURRENT_PERIOD = '2017-13';
-const CURRENT_PERIOD_LABEL = 'Jan 1 - Jan 14';
-const NEXT_PERIOD = '2017-14';
-const NEXT_PERIOD_LABEL = 'Jan 15 - Jan 28';
-const PREVIOUS_PERIOD = '2016-38';
-const PREVIOUS_PERIOD_LABEL = 'Dec 18 - Dec 31';
-const CURRENT_CALENDAR_MONTH = '2017-01';
-
-function getPayPeriodCheckbox(page: Page) {
-  return page.getByRole('checkbox', { name: 'Budget by pay period' });
-}
-
-async function selectPayFrequency(page: Page, frequencyLabel: string) {
-  // The pay period section only mounts once the experimental flag has
-  // landed; wait for it rather than racing the settings re-render.
-  const frequencySelect = page.locator('#pay-period-frequency');
-  await frequencySelect.waitFor({ state: 'visible', timeout: 15000 });
-  await frequencySelect.click();
-  await page.getByRole('button', { name: frequencyLabel, exact: true }).click();
-}
-
-/**
- * Toggles the "Budget by pay period" checkbox into the desired state.
- *
- * The control is disabled for as long as the save is in flight — the
- * server cold-builds every budget column for the new mode before the pref
- * save resolves — so one click is enough; just wait for it to come back.
- */
-async function togglePayPeriods(page: Page, enabled: boolean) {
-  const checkbox = getPayPeriodCheckbox(page);
-  await expect(checkbox).toBeEnabled();
-
-  if ((await checkbox.isChecked()) === enabled) {
-    return;
-  }
-
-  await checkbox.click();
-  await expect(checkbox).toBeChecked({ checked: enabled, timeout: 60000 });
-  await expect(checkbox).toBeEnabled({ timeout: 60000 });
-}
-
-/**
- * Configure a biweekly pay period cadence and turn on pay period
- * budgeting. Assumes the pay period settings section is already visible
- * (i.e. the 'Pay periods' feature flag is enabled).
- */
-async function configureAndEnablePayPeriods(page: Page) {
-  await selectPayFrequency(page, PAY_PERIOD_FREQUENCY_LABEL);
-  await page.locator('#pay-period-start-date').fill(PAY_PERIOD_START_DATE);
-  await togglePayPeriods(page, true);
-}
+import {
+  configureAndEnablePayPeriods,
+  CURRENT_CALENDAR_MONTH,
+  CURRENT_PERIOD,
+  CURRENT_PERIOD_LABEL,
+  getPayPeriodCheckbox,
+  NEXT_PERIOD,
+  NEXT_PERIOD_LABEL,
+  PAY_PERIOD_FREQUENCY_LABEL,
+  PAY_PERIOD_START_DATE,
+  PREVIOUS_PERIOD,
+  PREVIOUS_PERIOD_LABEL,
+  selectPayFrequency,
+  togglePayPeriods,
+} from './pay-period-helpers';
 
 test.describe('Pay period settings', () => {
   let page: Page;
@@ -81,6 +40,9 @@ test.describe('Pay period settings', () => {
   });
 
   test.afterEach(async () => {
+    // The shared helper activates the cadence in this process too; clear it
+    // so a later test can't inherit it.
+    resetPayPeriodConfigForTesting();
     await page?.close();
   });
 
@@ -236,6 +198,9 @@ test.describe('Budget in pay period mode', () => {
   });
 
   test.afterEach(async () => {
+    // The shared helper activates the cadence in this process too; clear it
+    // so a later test can't inherit it.
+    resetPayPeriodConfigForTesting();
     await page?.close();
   });
 

--- a/packages/desktop-client/e2e/pay-periods.test.ts
+++ b/packages/desktop-client/e2e/pay-periods.test.ts
@@ -73,7 +73,12 @@ test.describe('Pay period settings', () => {
     await selectPayFrequency(page, PAY_PERIOD_FREQUENCY_LABEL);
     await expect(checkbox).toBeDisabled();
 
-    await page.locator('#pay-period-start-date').fill(PAY_PERIOD_START_DATE);
+    // The date commits on blur/Enter, not per keystroke — a native date
+    // input emits "valid" partial values while the year is being typed.
+    const startDateInput = page.locator('#pay-period-start-date');
+    await startDateInput.fill(PAY_PERIOD_START_DATE);
+    await expect(checkbox).toBeDisabled();
+    await startDateInput.press('Enter');
     await expect(checkbox).toBeEnabled();
 
     // The click is only acknowledged once the server has rebuilt the

--- a/packages/desktop-client/e2e/pay-periods.test.ts
+++ b/packages/desktop-client/e2e/pay-periods.test.ts
@@ -34,21 +34,21 @@ async function selectPayFrequency(page: Page, frequencyLabel: string) {
 /**
  * Toggles the "Budget by pay period" checkbox into the desired state.
  *
- * Clicks on the settings checkboxes can race a re-render and get lost,
- * but a click that did land resolves slowly — the synced pref (and so
- * the checkbox) only updates once the server has rebuilt every budget
- * sheet for the new mode. So lost clicks are retried, with an inner wait
- * long enough to never double-click during a legitimate in-flight save.
+ * The control is disabled for as long as the save is in flight — the
+ * server cold-builds every budget column for the new mode before the pref
+ * save resolves — so one click is enough; just wait for it to come back.
  */
 async function togglePayPeriods(page: Page, enabled: boolean) {
   const checkbox = getPayPeriodCheckbox(page);
   await expect(checkbox).toBeEnabled();
-  await expect(async () => {
-    if ((await checkbox.isChecked()) !== enabled) {
-      await checkbox.click();
-    }
-    await expect(checkbox).toBeChecked({ checked: enabled, timeout: 20000 });
-  }).toPass({ timeout: 120000 });
+
+  if ((await checkbox.isChecked()) === enabled) {
+    return;
+  }
+
+  await checkbox.click();
+  await expect(checkbox).toBeChecked({ checked: enabled, timeout: 60000 });
+  await expect(checkbox).toBeEnabled({ timeout: 60000 });
 }
 
 /**
@@ -114,8 +114,11 @@ test.describe('Pay period settings', () => {
     await page.locator('#pay-period-start-date').fill(PAY_PERIOD_START_DATE);
     await expect(checkbox).toBeEnabled();
 
+    // The click is only acknowledged once the server has rebuilt the
+    // budget sheets for the new mode.
     await checkbox.click();
-    await expect(checkbox).toBeChecked();
+    await expect(checkbox).toBeChecked({ timeout: 60000 });
+    await expect(checkbox).toBeEnabled({ timeout: 60000 });
   });
 
   test('disabling pay periods returns the budget page to calendar months', async () => {
@@ -149,6 +152,50 @@ test.describe('Pay period settings', () => {
     await expect(
       budgetPage.budgetSummary.nth(1).getByText('January'),
     ).toBeVisible();
+  });
+
+  test('undoing the pay period toggle keeps the UI in sync with the server', async () => {
+    const settingsPage = await navigation.goToSettingsPage();
+    await settingsPage.enableExperimentalFeature('Pay periods');
+    await configureAndEnablePayPeriods(page);
+
+    const checkbox = getPayPeriodCheckbox(page);
+
+    // Undo reverts the preference server-side, which rebuilds the budget
+    // sheets back to calendar months. The client is told about it and must
+    // follow — otherwise the checkbox would keep claiming pay periods are
+    // on and the budget page would ask for sheets that no longer exist.
+    // The global Ctrl+Z handler ignores the shortcut while an input has
+    // focus, and the toggle click left the checkbox focused.
+    await page.evaluate(() => {
+      (document.activeElement as HTMLElement | null)?.blur();
+    });
+    await page.keyboard.press('Control+z');
+
+    await expect(checkbox).toBeChecked({ checked: false, timeout: 60000 });
+    await expect(checkbox).toBeEnabled({ timeout: 60000 });
+
+    const budgetPage = await navigation.goToBudgetPage();
+    await expect(budgetPage.selectedMonthButton).toHaveAttribute(
+      'data-month',
+      CURRENT_CALENDAR_MONTH,
+      { timeout: 60000 },
+    );
+
+    // No error boundary, either the route-level one or the app-level one.
+    await expect(
+      page.getByText('Something went wrong loading this section.'),
+    ).toHaveCount(0);
+    await expect(
+      page.getByText('There was an unrecoverable error in the UI. Sorry!'),
+    ).toHaveCount(0);
+
+    // The table must show real calendar-month data rather than the zeroed
+    // out cells of a sheet the client is no longer aligned with.
+    await expect(budgetPage.budgetTable).toBeVisible();
+    await expect
+      .poll(() => budgetPage.getTotalSpent(), { timeout: 30000 })
+      .not.toEqual(0);
   });
 });
 

--- a/packages/desktop-client/e2e/pay-periods.test.ts
+++ b/packages/desktop-client/e2e/pay-periods.test.ts
@@ -159,6 +159,59 @@ test.describe('Pay period settings', () => {
       .poll(() => budgetPage.getTotalSpent(), { timeout: 30000 })
       .not.toEqual(0);
   });
+
+  // The test above undoes from the *settings* page, so the budget page
+  // mounts fresh in the new mode. This one undoes while it is already on
+  // screen, exercising the re-initialization path: the config registry is
+  // updated during render, so for one render the requested months are in the
+  // new mode while the fetched bounds are still in the old one.
+  //
+  // Scope note — this is a smoke test, not a regression test for the mixed
+  // bounds throw. Reaching that needs the stale bounds to *start* in the
+  // same calendar year as the requested month, and under Playwright the
+  // clock is pinned to 2017-01-01 with a test file whose history reaches
+  // back into 2016, so the bounds always start in the prior year and the
+  // clamp never takes one end from each mode. The throw itself is covered by
+  // src/components/budget/MonthsContext.test.ts.
+  test('changing the cadence while the budget page is open does not break it', async () => {
+    const settingsPage = await navigation.goToSettingsPage();
+    await settingsPage.enableExperimentalFeature('Pay periods');
+    await configureAndEnablePayPeriods(page);
+
+    const budgetPage = await navigation.goToBudgetPage();
+    await expect(budgetPage.selectedMonthButton).toHaveAttribute(
+      'data-month',
+      CURRENT_PERIOD,
+      { timeout: 60000 },
+    );
+
+    // Undo the preference without leaving the page. The global handler
+    // ignores the shortcut while an input has focus.
+    await page.evaluate(() => {
+      (document.activeElement as HTMLElement | null)?.blur();
+    });
+    await page.keyboard.press('Control+z');
+
+    // The page has to survive the switch and settle into calendar months.
+    await expect(budgetPage.selectedMonthButton).toHaveAttribute(
+      'data-month',
+      CURRENT_CALENDAR_MONTH,
+      { timeout: 60000 },
+    );
+
+    await expect(
+      page.getByText('Something went wrong loading this section.'),
+    ).toHaveCount(0);
+    await expect(
+      page.getByText('There was an unrecoverable error in the UI. Sorry!'),
+    ).toHaveCount(0);
+
+    // Alive *and* showing data — a blank but un-crashed page must not pass.
+    await expect(budgetPage.budgetTable).toBeVisible();
+    await expect
+      .poll(() => budgetPage.getTotalSpent(), { timeout: 30000 })
+      .not.toEqual(0);
+  });
 });
 
 test.describe('Budget in pay period mode', () => {

--- a/packages/desktop-client/src/components/budget/MonthsContext.test.ts
+++ b/packages/desktop-client/src/components/budget/MonthsContext.test.ts
@@ -1,0 +1,75 @@
+import * as monthUtils from '@actual-app/core/shared/months';
+import {
+  resetPayPeriodConfigForTesting,
+  setPayPeriodConfig,
+} from '@actual-app/core/shared/pay-period-config';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getValidMonthBounds } from './MonthsContext';
+
+/**
+ * `getValidMonthBounds` clamps the requested window to the budget's bounds
+ * by comparing the two as strings. That is fine while both describe the same
+ * budgeting mode, but the pay period configuration can change while the
+ * budget page is mounted (an undo, or a sync from another device), and the
+ * registry that resolves period IDs is updated during render — so for one
+ * render the requested months are in the new mode while the bounds fetched
+ * from the server are still in the old one.
+ *
+ * These tests pin down when that produces a mixed pair, which
+ * `rangeInclusive` refuses to expand. `Budget` keeps such a pair away from
+ * the renderer by tagging its bounds with the cadence they were fetched for
+ * (see components/budget/index.tsx).
+ */
+describe('getValidMonthBounds with a stale cadence', () => {
+  beforeEach(() => {
+    setPayPeriodConfig({ payFrequency: 'biweekly', startDate: '2017-01-06' });
+  });
+
+  afterEach(() => {
+    resetPayPeriodConfigForTesting();
+  });
+
+  it('mixes the two kinds when the clamp takes one end from each', () => {
+    // Pay periods have just been switched off: the requested months are
+    // calendar again, but these bounds were fetched while they were on and
+    // start inside the same calendar year.
+    const stalePeriodBounds = { start: '2017-13', end: '2017-38' };
+
+    const bounds = getValidMonthBounds(stalePeriodBounds, '2017-01', '2017-03');
+
+    // Every calendar month sorts below every pay period of the same year
+    // ('2017-01' < '2017-13'), so the start clamps to the period bound while
+    // the end keeps the calendar month.
+    expect(bounds).toEqual({ start: '2017-13', end: '2017-03' });
+    expect(() => monthUtils.rangeInclusive('2017-13', '2017-03')).toThrow(
+      /mixing/,
+    );
+  });
+
+  it('does not mix when the stale bounds start in an earlier year', () => {
+    // The same switch-off against a budget whose data reaches back a year:
+    // '2017-01' > '2016-32', so no clamp happens and both ends stay
+    // calendar. This is why the hazard is invisible on a long-lived budget
+    // and shows up on one whose history starts in the current year.
+    const stalePeriodBounds = { start: '2016-32', end: '2017-38' };
+
+    const bounds = getValidMonthBounds(stalePeriodBounds, '2017-01', '2017-03');
+
+    expect(bounds).toEqual({ start: '2017-01', end: '2017-03' });
+    expect(() => monthUtils.rangeInclusive('2017-01', '2017-03')).not.toThrow();
+  });
+
+  it('is unaffected once both ends describe the same mode', () => {
+    const periodBounds = { start: '2017-13', end: '2017-38' };
+
+    const bounds = getValidMonthBounds(periodBounds, '2017-14', '2017-16');
+
+    expect(bounds).toEqual({ start: '2017-14', end: '2017-16' });
+    expect(monthUtils.rangeInclusive('2017-14', '2017-16')).toEqual([
+      '2017-14',
+      '2017-15',
+      '2017-16',
+    ]);
+  });
+});

--- a/packages/desktop-client/src/components/budget/MonthsContext.test.ts
+++ b/packages/desktop-client/src/components/budget/MonthsContext.test.ts
@@ -8,6 +8,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { getValidMonthBounds } from './MonthsContext';
 
 /**
+ * HAZARD CHARACTERISATION, not regression coverage of a fix.
+ *
  * `getValidMonthBounds` clamps the requested window to the budget's bounds
  * by comparing the two as strings. That is fine while both describe the same
  * budgeting mode, but the pay period configuration can change while the
@@ -16,10 +18,16 @@ import { getValidMonthBounds } from './MonthsContext';
  * render the requested months are in the new mode while the bounds fetched
  * from the server are still in the old one.
  *
- * These tests pin down when that produces a mixed pair, which
- * `rangeInclusive` refuses to expand. `Budget` keeps such a pair away from
- * the renderer by tagging its bounds with the cadence they were fetched for
- * (see components/budget/index.tsx).
+ * These tests pin down exactly when that produces a mixed pair, which
+ * `rangeInclusive` refuses to expand: only when the clamp takes one end from
+ * each mode, i.e. when the stale bounds *start* in the same calendar year as
+ * the request. They exercise unmodified code plus the guard in
+ * `rangeInclusive` — they would still pass if the `bounds.configKey` gate in
+ * components/budget/index.tsx (the mitigation that keeps the mixed pair away
+ * from the renderer) were deleted, because they don't render `Budget`. What
+ * they do catch is anyone weakening the `rangeInclusive` mixing guard, and
+ * they document why the hazard is invisible on budgets with prior-year
+ * history.
  */
 describe('getValidMonthBounds with a stale cadence', () => {
   beforeEach(() => {

--- a/packages/desktop-client/src/components/budget/goals/formatMonthLabel.ts
+++ b/packages/desktop-client/src/components/budget/goals/formatMonthLabel.ts
@@ -19,5 +19,5 @@ export function formatMonthLabel(
     return payPeriodsActive() ? monthUtils.nameForMonth(month, locale) : month;
   }
   if (!monthUtils.isValidYearMonth(month)) return month;
-  return monthUtils.format(`${month}-01`, 'MMM yyyy', locale);
+  return monthUtils.format(month, 'MMM yyyy', locale);
 }

--- a/packages/desktop-client/src/components/budget/index.tsx
+++ b/packages/desktop-client/src/components/budget/index.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useEffectEvent, useMemo, useState } from 'react';
 import type { ComponentType } from 'react';
 
+import { AnimatedLoading } from '@actual-app/components/icons/AnimatedLoading';
 import { styles } from '@actual-app/components/styles';
 import { View } from '@actual-app/components/view';
 import { send } from '@actual-app/core/platform/client/connection';
@@ -26,7 +27,10 @@ import { useCategories } from '#hooks/useCategories';
 import { useGlobalPref } from '#hooks/useGlobalPref';
 import { useLocalPref } from '#hooks/useLocalPref';
 import { useNavigate } from '#hooks/useNavigate';
-import { usePayPeriodConfig } from '#hooks/usePayPeriodConfig';
+import {
+  payPeriodConfigKey,
+  usePayPeriodConfig,
+} from '#hooks/usePayPeriodConfig';
 import { SheetNameProvider } from '#hooks/useSheetName';
 import { useSpreadsheet } from '#hooks/useSpreadsheet';
 import { useSyncedPref } from '#hooks/useSyncedPref';
@@ -79,7 +83,18 @@ export function Budget() {
 
     void run();
   });
-  useEffect(() => init(), []);
+
+  // The bounds and the prewarmed cells are expressed in the units of the
+  // active budget cadence (calendar months or pay period IDs), so both go
+  // stale when the pay period configuration changes. That normally happens
+  // on the settings route (this page is unmounted), but a change synced
+  // from another device — or an undo — can land while the budget is on
+  // screen, so re-run the initialization and re-gate the table on it.
+  const configKey = payPeriodConfigKey(payPeriodConfig);
+  useEffect(() => {
+    setInitialized(false);
+    init();
+  }, [configKey]);
 
   const loadBoundBudgets = useEffectEvent(() => {
     void send('get-budget-bounds').then(({ start, end }) => {
@@ -204,7 +219,17 @@ export function Budget() {
   };
 
   if (!initialized || !categoryGroups) {
-    return null;
+    return (
+      <View
+        style={{
+          ...styles.page,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <AnimatedLoading width={25} height={25} />
+      </View>
+    );
   }
 
   let table;

--- a/packages/desktop-client/src/components/budget/index.tsx
+++ b/packages/desktop-client/src/components/budget/index.tsx
@@ -55,10 +55,19 @@ export function Budget() {
   // pay periods are active, or vice versa) must not leak into month math —
   // mixing the two kinds produces broken ranges.
   const startMonth = monthUtils.resolveStartMonth(startMonthPref, currentMonth);
-  const [bounds, setBounds] = useState({
+  // `bounds` is tagged with the cadence it was fetched for. The registry
+  // that resolves pay period IDs is updated *during* render (see
+  // usePayPeriodConfigSync), so on the render where the cadence flips,
+  // `startMonth` is already expressed in the new mode while this state
+  // still holds the old mode's bounds. Rendering the table with that pair
+  // throws (`rangeInclusive` refuses to mix a calendar month and a pay
+  // period), so the tag lets the gate below reject the stale pair in the
+  // same render rather than one effect later.
+  const [bounds, setBounds] = useState(() => ({
     start: startMonth,
     end: startMonth,
-  });
+    configKey: payPeriodConfigKey(payPeriodConfig),
+  }));
   const [budgetType = 'envelope'] = useSyncedPref('budgetType');
   const [maxMonthsPref] = useGlobalPref('maxMonths');
   const maxMonths = maxMonthsPref || 1;
@@ -68,8 +77,13 @@ export function Budget() {
 
   const init = useEffectEvent(() => {
     async function run() {
+      // Captured before the await: if the cadence changes again while this
+      // request is in flight, the bounds it returns describe the cadence
+      // that was active when it was sent, not the one active when it
+      // resolves.
+      const requestedConfigKey = payPeriodConfigKey(payPeriodConfig);
       const { start, end } = await send('get-budget-bounds');
-      setBounds({ start, end });
+      setBounds({ start, end, configKey: requestedConfigKey });
 
       await prewarmAllMonths(
         budgetType,
@@ -97,9 +111,10 @@ export function Budget() {
   }, [configKey]);
 
   const loadBoundBudgets = useEffectEvent(() => {
+    const requestedConfigKey = payPeriodConfigKey(payPeriodConfig);
     void send('get-budget-bounds').then(({ start, end }) => {
       if (bounds.start !== start || bounds.end !== end) {
-        setBounds({ start, end });
+        setBounds({ start, end, configKey: requestedConfigKey });
       }
     });
   });
@@ -218,7 +233,9 @@ export function Budget() {
     applyBudgetAction.mutate({ month, type, args });
   };
 
-  if (!initialized || !categoryGroups) {
+  // `bounds.configKey !== configKey` catches the render where the cadence
+  // has already flipped but the refetched bounds haven't arrived yet.
+  if (!initialized || bounds.configKey !== configKey || !categoryGroups) {
     return (
       <View
         style={{

--- a/packages/desktop-client/src/components/budget/index.tsx
+++ b/packages/desktop-client/src/components/budget/index.tsx
@@ -7,6 +7,7 @@ import { styles } from '@actual-app/components/styles';
 import { View } from '@actual-app/components/view';
 import { send } from '@actual-app/core/platform/client/connection';
 import * as monthUtils from '@actual-app/core/shared/months';
+import { getPayPeriodConfig } from '@actual-app/core/shared/pay-period-config';
 import { getPayPeriodDateFilter } from '@actual-app/core/shared/pay-periods';
 import type {
   CategoryEntity,
@@ -75,6 +76,29 @@ export function Budget() {
   const { data: { grouped: categoryGroups } = { grouped: [] } } =
     useCategories();
 
+  // A bounds response is only allowed to land if the cadence it was
+  // requested under is still the active one — a response from before a
+  // cadence change would otherwise overwrite the fresh bounds with a stale
+  // tag, closing the render gate below with nothing left to reopen it.
+  // The registry is the live source of the active cadence, updated during
+  // render by usePayPeriodConfigSync.
+  const applyBoundsIfCurrent = (
+    requestedConfigKey: string,
+    start: string,
+    end: string,
+  ) => {
+    if (requestedConfigKey !== payPeriodConfigKey(getPayPeriodConfig())) {
+      return;
+    }
+    setBounds(prev =>
+      prev.start !== start ||
+      prev.end !== end ||
+      prev.configKey !== requestedConfigKey
+        ? { start, end, configKey: requestedConfigKey }
+        : prev,
+    );
+  };
+
   const init = useEffectEvent(() => {
     async function run() {
       // Captured before the await: if the cadence changes again while this
@@ -83,7 +107,7 @@ export function Budget() {
       // resolves.
       const requestedConfigKey = payPeriodConfigKey(payPeriodConfig);
       const { start, end } = await send('get-budget-bounds');
-      setBounds({ start, end, configKey: requestedConfigKey });
+      applyBoundsIfCurrent(requestedConfigKey, start, end);
 
       await prewarmAllMonths(
         budgetType,
@@ -95,7 +119,20 @@ export function Budget() {
       setInitialized(true);
     }
 
-    void run();
+    void run().catch(error => {
+      console.error('Failed to initialize the budget view', error);
+      // Degrade to a single-column view in the active cadence rather than
+      // an unrecoverable spinner: without bounds in the current mode the
+      // gate below never opens, and nothing else re-runs init.
+      const currentKey = payPeriodConfigKey(getPayPeriodConfig());
+      const fallbackMonth = monthUtils.currentBudgetMonth();
+      setBounds({
+        start: fallbackMonth,
+        end: fallbackMonth,
+        configKey: currentKey,
+      });
+      setInitialized(true);
+    });
   });
 
   // The bounds and the prewarmed cells are expressed in the units of the
@@ -112,11 +149,15 @@ export function Budget() {
 
   const loadBoundBudgets = useEffectEvent(() => {
     const requestedConfigKey = payPeriodConfigKey(payPeriodConfig);
-    void send('get-budget-bounds').then(({ start, end }) => {
-      if (bounds.start !== start || bounds.end !== end) {
-        setBounds({ start, end, configKey: requestedConfigKey });
-      }
-    });
+    void send('get-budget-bounds')
+      .then(({ start, end }) => {
+        applyBoundsIfCurrent(requestedConfigKey, start, end);
+      })
+      .catch(error => {
+        // Refreshing the bounds is an optimization; the init() bounds are
+        // already in place, so a failed refresh is not fatal.
+        console.error('Failed to refresh budget bounds', error);
+      });
   });
   useEffect(() => loadBoundBudgets(), []);
 

--- a/packages/desktop-client/src/components/mobile/budget/BudgetPage.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetPage.tsx
@@ -100,10 +100,21 @@ export function BudgetPage() {
   // pay period ID persisted before pay periods were switched off) — fall
   // back to the current budget month instead of crashing on it.
   const startMonth = monthUtils.resolveStartMonth(startMonthPref, currMonth);
-  const [monthBounds, setMonthBounds] = useState({
+  // Switching pay periods on or off moves `startMonth` between calendar
+  // months and period IDs, but changing only the cadence can leave it
+  // untouched ('2017-13' is a valid period under every frequency) — the
+  // bounds and prewarmed cells still go stale, so depend on the config too.
+  const payPeriodConfig = usePayPeriodConfig();
+  const configKey = payPeriodConfigKey(payPeriodConfig);
+  // Tagged with the cadence these bounds describe; see the same pattern on
+  // desktop (components/budget/index.tsx). Mobile only string-compares the
+  // bounds so a stale pair doesn't throw, but it does enable or disable the
+  // previous/next arrows against the wrong end of the budget.
+  const [monthBounds, setMonthBounds] = useState(() => ({
     start: startMonth,
     end: startMonth,
-  });
+    configKey,
+  }));
   // const [editMode, setEditMode] = useState(false);
   const [initialized, setInitialized] = useState(false);
   const [_numberFormat] = useSyncedPref('numberFormat');
@@ -119,17 +130,13 @@ export function BudgetPage() {
   const deleteCategoryGroup = useDeleteCategoryGroupMutation();
   const sortCategories = useSortCategoriesMutation();
 
-  // Switching pay periods on or off moves `startMonth` between calendar
-  // months and period IDs, but changing only the cadence can leave it
-  // untouched ('2017-13' is a valid period under every frequency) — the
-  // bounds and prewarmed cells still go stale, so depend on the config too.
-  const payPeriodConfig = usePayPeriodConfig();
-  const configKey = payPeriodConfigKey(payPeriodConfig);
-
   useEffect(() => {
     async function init() {
+      // Captured before the await; a cadence change while this request is
+      // in flight would otherwise mis-tag the bounds it returns.
+      const requestedConfigKey = configKey;
       const { start, end } = await send('get-budget-bounds');
-      setMonthBounds({ start, end });
+      setMonthBounds({ start, end, configKey: requestedConfigKey });
 
       await prewarmMonth(budgetType, spreadsheet, startMonth);
 
@@ -555,7 +562,9 @@ export function BudgetPage() {
     onToggleHiddenCategories,
   ]);
 
-  if (!categoryGroups || !initialized) {
+  // `monthBounds.configKey !== configKey` catches the render where the
+  // cadence has already flipped but the refetched bounds haven't landed.
+  if (!categoryGroups || !initialized || monthBounds.configKey !== configKey) {
     return (
       <View
         style={{

--- a/packages/desktop-client/src/components/mobile/budget/BudgetPage.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetPage.tsx
@@ -58,7 +58,10 @@ import { useLocale } from '#hooks/useLocale';
 import { useLocalPref } from '#hooks/useLocalPref';
 import { useNavigate } from '#hooks/useNavigate';
 import { useOverspentCategories } from '#hooks/useOverspentCategories';
-import { usePayPeriodConfig } from '#hooks/usePayPeriodConfig';
+import {
+  payPeriodConfigKey,
+  usePayPeriodConfig,
+} from '#hooks/usePayPeriodConfig';
 import { SheetNameProvider } from '#hooks/useSheetName';
 import { useSheetValue } from '#hooks/useSheetValue';
 import { useSpreadsheet } from '#hooks/useSpreadsheet';
@@ -116,6 +119,13 @@ export function BudgetPage() {
   const deleteCategoryGroup = useDeleteCategoryGroupMutation();
   const sortCategories = useSortCategoriesMutation();
 
+  // Switching pay periods on or off moves `startMonth` between calendar
+  // months and period IDs, but changing only the cadence can leave it
+  // untouched ('2017-13' is a valid period under every frequency) — the
+  // bounds and prewarmed cells still go stale, so depend on the config too.
+  const payPeriodConfig = usePayPeriodConfig();
+  const configKey = payPeriodConfigKey(payPeriodConfig);
+
   useEffect(() => {
     async function init() {
       const { start, end } = await send('get-budget-bounds');
@@ -127,7 +137,7 @@ export function BudgetPage() {
     }
 
     void init();
-  }, [budgetType, startMonth, dispatch, spreadsheet]);
+  }, [budgetType, startMonth, dispatch, spreadsheet, configKey]);
 
   const onBudgetAction = useCallback(
     async (month, type, args) => {

--- a/packages/desktop-client/src/components/mobile/budget/BudgetPage.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetPage.tsx
@@ -28,6 +28,7 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import { send } from '@actual-app/core/platform/client/connection';
 import * as monthUtils from '@actual-app/core/shared/months';
+import { getPayPeriodConfig } from '@actual-app/core/shared/pay-period-config';
 import {
   getPayPeriodLabel,
   isPayPeriod,
@@ -133,17 +134,33 @@ export function BudgetPage() {
   useEffect(() => {
     async function init() {
       // Captured before the await; a cadence change while this request is
-      // in flight would otherwise mis-tag the bounds it returns.
+      // in flight would otherwise mis-tag the bounds it returns. The
+      // registry (kept live by usePayPeriodConfigSync) is checked again on
+      // resolution so a response from before the change cannot overwrite
+      // the fresh bounds with a stale tag.
       const requestedConfigKey = configKey;
       const { start, end } = await send('get-budget-bounds');
-      setMonthBounds({ start, end, configKey: requestedConfigKey });
+      if (requestedConfigKey === payPeriodConfigKey(getPayPeriodConfig())) {
+        setMonthBounds({ start, end, configKey: requestedConfigKey });
+      }
 
       await prewarmMonth(budgetType, spreadsheet, startMonth);
 
       setInitialized(true);
     }
 
-    void init();
+    void init().catch(error => {
+      console.error('Failed to initialize the mobile budget view', error);
+      // Show the single current column rather than an unrecoverable
+      // spinner; nothing else re-runs this effect.
+      const fallbackMonth = monthUtils.currentBudgetMonth();
+      setMonthBounds({
+        start: fallbackMonth,
+        end: fallbackMonth,
+        configKey: payPeriodConfigKey(getPayPeriodConfig()),
+      });
+      setInitialized(true);
+    });
   }, [budgetType, startMonth, dispatch, spreadsheet, configKey]);
 
   const onBudgetAction = useCallback(

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationEditorPane.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationEditorPane.tsx
@@ -80,7 +80,7 @@ function getDefaultWeeklyStart(entries: AutomationEntry[]): string {
       (template.type === 'by' || template.type === 'spend') &&
       template.month
     ) {
-      starts.push(`${template.month}-01`);
+      starts.push(firstDayOfMonth(template.month));
     }
   }
 

--- a/packages/desktop-client/src/components/modals/EnvelopeBudgetSummaryModal.tsx
+++ b/packages/desktop-client/src/components/modals/EnvelopeBudgetSummaryModal.tsx
@@ -7,6 +7,10 @@ import {
   prevMonth,
   sheetForMonth,
 } from '@actual-app/core/shared/months';
+import {
+  getPayPeriodLabel,
+  isPayPeriod,
+} from '@actual-app/core/shared/pay-periods';
 import type { CategoryEntity } from '@actual-app/core/types/models/category';
 
 import { ToBudgetAmount } from '#components/budget/envelope/budgetsummary/ToBudgetAmount';
@@ -16,6 +20,7 @@ import { Modal, ModalCloseButton, ModalHeader } from '#components/common/Modal';
 import { useCategoriesById } from '#hooks/useCategories';
 import { useFormat } from '#hooks/useFormat';
 import { useLocale } from '#hooks/useLocale';
+import { usePayPeriodConfig } from '#hooks/usePayPeriodConfig';
 import { SheetNameProvider } from '#hooks/useSheetName';
 import { useUndo } from '#hooks/useUndo';
 import { collapseModals, pushModal } from '#modals/modalsSlice';
@@ -37,7 +42,16 @@ export function EnvelopeBudgetSummaryModal({
 
   const locale = useLocale();
   const dispatch = useDispatch();
-  const prevMonthName = formatMonth(prevMonth(month), 'MMM', locale);
+  const payPeriodConfig = usePayPeriodConfig();
+  // "Leftover from Jan" is ambiguous when the previous budget column is a
+  // pay period — its start month is usually the same as the current one's,
+  // so show the period's date range instead (matching the desktop summary,
+  // budget/envelope/budgetsummary/BudgetSummary.tsx).
+  const previousMonth = prevMonth(month);
+  const prevMonthName =
+    payPeriodConfig && isPayPeriod(month)
+      ? getPayPeriodLabel(previousMonth, payPeriodConfig, 'short', locale)
+      : formatMonth(previousMonth, 'MMM', locale);
   const sheetValue =
     useEnvelopeSheetValue({
       name: envelopeBudget.toBudget,

--- a/packages/desktop-client/src/components/reports/BudgetDataUnavailable.tsx
+++ b/packages/desktop-client/src/components/reports/BudgetDataUnavailable.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Trans } from 'react-i18next';
+
+import { Block } from '@actual-app/components/block';
+import { styles } from '@actual-app/components/styles';
+import { theme } from '@actual-app/components/theme';
+import { View } from '@actual-app/components/view';
+
+/**
+ * Shown in place of a chart that reads budgeted amounts, when the budget is
+ * kept in pay periods rather than calendar months.
+ *
+ * These reports build calendar-month intervals and ask the budget for each
+ * one. While pay periods are active those months have no budget columns, so
+ * every value comes back empty and the chart would render a flat zero — a
+ * wrong number presented as a fact. Saying nothing is available is the
+ * honest alternative until the reports can aggregate the pay periods that
+ * overlap each interval, which needs a rule for periods that straddle a
+ * month boundary.
+ */
+export function BudgetDataUnavailable() {
+  return (
+    <View
+      style={{
+        flex: 1,
+        padding: 20,
+        justifyContent: 'center',
+        alignItems: 'center',
+        ...styles.delayedFadeIn,
+      }}
+    >
+      <Block
+        style={{
+          textAlign: 'center',
+          color: theme.pageTextSubdued,
+          ...styles.smallText,
+        }}
+      >
+        <Trans>
+          Budget reports aren't available while you budget by pay period.
+        </Trans>
+      </Block>
+    </View>
+  );
+}

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
@@ -27,6 +27,7 @@ import { FinancialText } from '#components/FinancialText';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { MobilePageHeader, Page, PageHeader } from '#components/Page';
 import { PrivacyFilter } from '#components/PrivacyFilter';
+import { BudgetDataUnavailable } from '#components/reports/BudgetDataUnavailable';
 import { Change } from '#components/reports/Change';
 import { BudgetAnalysisGraph } from '#components/reports/graphs/BudgetAnalysisGraph';
 import { Header } from '#components/reports/Header';
@@ -40,6 +41,7 @@ import { useDashboardWidget } from '#hooks/useDashboardWidget';
 import { useFormat } from '#hooks/useFormat';
 import { useLocale } from '#hooks/useLocale';
 import { useNavigate } from '#hooks/useNavigate';
+import { usePayPeriodConfig } from '#hooks/usePayPeriodConfig';
 import { useRuleConditionFilters } from '#hooks/useRuleConditionFilters';
 import { useSyncedPref } from '#hooks/useSyncedPref';
 import { addNotification } from '#notifications/notificationsSlice';
@@ -144,6 +146,9 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
   const dispatch = useDispatch();
   const { t } = useTranslation();
   const format = useFormat();
+  // Budgeted amounts are kept per pay period rather than per calendar
+  // month, which is what this report charts.
+  const isBudgetDataUnavailable = usePayPeriodConfig() != null;
 
   const {
     conditions,
@@ -345,6 +350,10 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
       t('Export budget analysis'),
     );
   };
+
+  if (isBudgetDataUnavailable) {
+    return <BudgetDataUnavailable />;
+  }
 
   if (!data || !allMonths) {
     return <LoadingIndicator />;

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
@@ -351,8 +351,32 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
     );
   };
 
+  const title = widget?.meta?.name || t('Budget Analysis');
+
+  // Keep the page chrome (title, mobile back button): unlike the transient
+  // loading state below, this one persists for as long as pay periods are
+  // on, and a bare centered sentence with no way back is a dead end on
+  // mobile.
   if (isBudgetDataUnavailable) {
-    return <BudgetDataUnavailable />;
+    return (
+      <Page
+        header={
+          isNarrowWidth ? (
+            <MobilePageHeader
+              title={title}
+              leftContent={
+                <MobileBackButton onPress={() => navigate('/reports')} />
+              }
+            />
+          ) : (
+            <PageHeader title={title} />
+          )
+        }
+        padding={0}
+      >
+        <BudgetDataUnavailable />
+      </Page>
+    );
   }
 
   if (!data || !allMonths) {
@@ -361,8 +385,6 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
 
   const latestInterval = data.intervalData[data.intervalData.length - 1];
   const endingBalance = latestInterval?.balance ?? 0;
-
-  const title = widget?.meta?.name || t('Budget Analysis');
 
   const onSaveWidgetName = async (newName: string) => {
     if (!widget) {

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysisCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysisCard.tsx
@@ -10,6 +10,7 @@ import type { BudgetAnalysisWidget } from '@actual-app/core/types/models';
 
 import { FinancialText } from '#components/FinancialText';
 import { PrivacyFilter } from '#components/PrivacyFilter';
+import { BudgetDataUnavailable } from '#components/reports/BudgetDataUnavailable';
 import { DateRange } from '#components/reports/DateRange';
 import { BudgetAnalysisGraph } from '#components/reports/graphs/BudgetAnalysisGraph';
 import { LoadingIndicator } from '#components/reports/LoadingIndicator';
@@ -19,6 +20,7 @@ import { calculateTimeRange } from '#components/reports/reportRanges';
 import { createBudgetAnalysisSpreadsheet } from '#components/reports/spreadsheets/budget-analysis-spreadsheet';
 import { useReport } from '#components/reports/useReport';
 import { useFormat } from '#hooks/useFormat';
+import { usePayPeriodConfig } from '#hooks/usePayPeriodConfig';
 
 type BudgetAnalysisCardProps = {
   widgetId: string;
@@ -35,6 +37,9 @@ export function BudgetAnalysisCard({
 }: BudgetAnalysisCardProps) {
   const { t } = useTranslation();
   const format = useFormat();
+  // Budgeted amounts are kept per pay period rather than per calendar
+  // month, which is what this report charts.
+  const isBudgetDataUnavailable = usePayPeriodConfig() != null;
 
   const [isCardHovered, setIsCardHovered] = useState(false);
   const [nameMenuOpen, setNameMenuOpen] = useState(false);
@@ -106,7 +111,7 @@ export function BudgetAnalysisCard({
               end={monthUtils.getMonth(endDate)}
             />
           </View>
-          {data && (
+          {data && !isBudgetDataUnavailable && (
             <View style={{ textAlign: 'right' }}>
               <Block
                 style={{
@@ -125,7 +130,9 @@ export function BudgetAnalysisCard({
             </View>
           )}
         </View>
-        {data ? (
+        {isBudgetDataUnavailable ? (
+          <BudgetDataUnavailable />
+        ) : data ? (
           <BudgetAnalysisGraph
             style={{ flex: 1 }}
             data={data}

--- a/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
@@ -62,6 +62,7 @@ import { useLocale } from '#hooks/useLocale';
 import { useLocalPref } from '#hooks/useLocalPref';
 import { useNavigate } from '#hooks/useNavigate';
 import { usePayees } from '#hooks/usePayees';
+import { usePayPeriodConfig } from '#hooks/usePayPeriodConfig';
 import { useReport as useCustomReport } from '#hooks/useReport';
 import { useRuleConditionFilters } from '#hooks/useRuleConditionFilters';
 import { useSyncedPref } from '#hooks/useSyncedPref';
@@ -495,12 +496,18 @@ function CustomReportInner({
   const sortByOp: sortByOpType = sortBy || 'desc';
   const { data: payees = [] } = usePayees();
   const { data: accounts = [] } = useAccounts();
+  const payPeriodConfig = usePayPeriodConfig();
 
   const hasWarning = calculateHasWarning(conditions, {
     categories: categories.list,
     payees,
     accounts,
   });
+
+  // The "Budgeted" balance type reads budgeted amounts per calendar month,
+  // and those columns don't exist while the budget is kept in pay periods.
+  const isBudgetDataUnavailable =
+    balanceTypeOp === 'totalBudgeted' && payPeriodConfig != null;
 
   useEffect(() => {
     if (balanceTypeOp !== 'totalBudgeted') {
@@ -1004,6 +1011,13 @@ function CustomReportInner({
                 </Warning>
               )}
             </View>
+          )}
+          {isBudgetDataUnavailable && (
+            <Warning style={{ paddingTop: 5, paddingBottom: 5 }}>
+              {t(
+                "Budgeted amounts aren't available while you budget by pay period, so this report has no data to show. Choose a different balance type to see this report.",
+              )}
+            </Warning>
           )}
           <View
             id="custom-report-content"

--- a/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
@@ -30,6 +30,7 @@ import { FinancialText } from '#components/FinancialText';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { MobilePageHeader, Page, PageHeader } from '#components/Page';
 import { PrivacyFilter } from '#components/PrivacyFilter';
+import { BudgetDataUnavailable } from '#components/reports/BudgetDataUnavailable';
 import { ChooseGraph } from '#components/reports/ChooseGraph';
 import {
   defaultsGraphList,
@@ -1033,35 +1034,41 @@ function CustomReportInner({
                 padding: 10,
               }}
             >
-              {graphType !== 'TableGraph' && data && (
-                <View
-                  style={{
-                    alignItems: 'flex-end',
-                    paddingTop: 10,
-                  }}
-                >
+              {graphType !== 'TableGraph' &&
+                data &&
+                !isBudgetDataUnavailable && (
                   <View
                     style={{
-                      ...styles.mediumText,
-                      fontWeight: 500,
-                      marginBottom: 5,
+                      alignItems: 'flex-end',
+                      paddingTop: 10,
                     }}
                   >
-                    <AlignedText
-                      left={<Block>{balanceType}:</Block>}
-                      right={
-                        <FinancialText>
-                          <PrivacyFilter>
-                            {format(data[balanceTypeOp], 'financial')}
-                          </PrivacyFilter>
-                        </FinancialText>
-                      }
-                    />
+                    <View
+                      style={{
+                        ...styles.mediumText,
+                        fontWeight: 500,
+                        marginBottom: 5,
+                      }}
+                    >
+                      <AlignedText
+                        left={<Block>{balanceType}:</Block>}
+                        right={
+                          <FinancialText>
+                            <PrivacyFilter>
+                              {format(data[balanceTypeOp], 'financial')}
+                            </PrivacyFilter>
+                          </FinancialText>
+                        }
+                      />
+                    </View>
                   </View>
-                </View>
-              )}
+                )}
               <View style={{ flex: 1, overflow: 'auto' }}>
-                {data ? (
+                {isBudgetDataUnavailable ? (
+                  // The warning above explains why; rendering the chart too
+                  // would present a $0.00 total as a fact.
+                  <BudgetDataUnavailable />
+                ) : data ? (
                   <ChooseGraph
                     data={data}
                     filters={conditions}
@@ -1083,33 +1090,36 @@ function CustomReportInner({
                 )}
               </View>
             </View>
-            {(viewLegend || viewSummary) && data && !isNarrowWidth && (
-              <View
-                style={{
-                  padding: 10,
-                  minWidth: 300,
-                  textAlign: 'center',
-                }}
-              >
-                {viewSummary && (
-                  <ReportSummary
-                    startDate={startDate}
-                    endDate={endDate}
-                    balanceTypeOp={balanceTypeOp}
-                    data={data}
-                    interval={interval}
-                    intervalsCount={intervals.length}
-                  />
-                )}
-                {viewLegend && (
-                  <ReportLegend
-                    legend={data.legend}
-                    groupBy={groupBy}
-                    interval={interval}
-                  />
-                )}
-              </View>
-            )}
+            {(viewLegend || viewSummary) &&
+              data &&
+              !isBudgetDataUnavailable &&
+              !isNarrowWidth && (
+                <View
+                  style={{
+                    padding: 10,
+                    minWidth: 300,
+                    textAlign: 'center',
+                  }}
+                >
+                  {viewSummary && (
+                    <ReportSummary
+                      startDate={startDate}
+                      endDate={endDate}
+                      balanceTypeOp={balanceTypeOp}
+                      data={data}
+                      interval={interval}
+                      intervalsCount={intervals.length}
+                    />
+                  )}
+                  {viewLegend && (
+                    <ReportLegend
+                      legend={data.legend}
+                      groupBy={groupBy}
+                      interval={interval}
+                    />
+                  )}
+                </View>
+              )}
           </View>
         </View>
       </View>

--- a/packages/desktop-client/src/components/reports/reports/GetCardData.tsx
+++ b/packages/desktop-client/src/components/reports/reports/GetCardData.tsx
@@ -16,6 +16,7 @@ import type {
 } from '@actual-app/core/types/models';
 import type { SyncedPrefs } from '@actual-app/core/types/prefs';
 
+import { BudgetDataUnavailable } from '#components/reports/BudgetDataUnavailable';
 import { ChooseGraph } from '#components/reports/ChooseGraph';
 import { getLiveRange } from '#components/reports/getLiveRange';
 import { LoadingIndicator } from '#components/reports/LoadingIndicator';
@@ -23,6 +24,7 @@ import { ReportOptions } from '#components/reports/ReportOptions';
 import { createCustomSpreadsheet } from '#components/reports/spreadsheets/custom-spreadsheet';
 import { createGroupedSpreadsheet } from '#components/reports/spreadsheets/grouped-spreadsheet';
 import { useReport } from '#components/reports/useReport';
+import { usePayPeriodConfig } from '#hooks/usePayPeriodConfig';
 import { useSyncedPref } from '#hooks/useSyncedPref';
 
 function ErrorFallback() {
@@ -85,6 +87,7 @@ export function GetCardData({
 }) {
   const { isNarrowWidth } = useResponsive();
   const [budgetType = 'envelope'] = useSyncedPref('budgetType');
+  const payPeriodConfig = usePayPeriodConfig();
 
   let startDate = report.startDate;
   let endDate = report.endDate;
@@ -177,6 +180,17 @@ export function GetCardData({
 
   const data =
     graphData && groupedData ? { ...graphData, groupedData } : graphData;
+
+  // A report saved with the Budgeted balance type reads budgeted amounts,
+  // which don't exist while budgeting by pay period — the query comes back
+  // empty and the card would render a well-formed chart of zeros with no
+  // hint that anything is wrong. Match BudgetAnalysisCard and say so.
+  const isBudgetDataUnavailable =
+    payPeriodConfig != null &&
+    ReportOptions.balanceTypeMap.get(report.balanceType) === 'totalBudgeted';
+  if (isBudgetDataUnavailable) {
+    return <BudgetDataUnavailable />;
+  }
 
   return data?.data ? (
     <ErrorBoundary FallbackComponent={ErrorFallback}>

--- a/packages/desktop-client/src/components/reports/reports/Sankey.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Sankey.tsx
@@ -52,6 +52,7 @@ import { useDashboardWidget } from '#hooks/useDashboardWidget';
 import { useFormatList } from '#hooks/useFormatList';
 import { useLocale } from '#hooks/useLocale';
 import { useNavigate } from '#hooks/useNavigate';
+import { usePayPeriodConfig } from '#hooks/usePayPeriodConfig';
 import { useResizeObserver } from '#hooks/useResizeObserver';
 import { useRuleConditionFilters } from '#hooks/useRuleConditionFilters';
 import { addNotification } from '#notifications/notificationsSlice';
@@ -339,9 +340,14 @@ function LayerSelector({
 type GraphModeSelectorProps = {
   mode: GraphMode;
   onChange: (mode: GraphMode) => void;
+  budgetedDisabled?: boolean;
 };
 
-function GraphModeSelector({ mode, onChange }: GraphModeSelectorProps) {
+function GraphModeSelector({
+  mode,
+  onChange,
+  budgetedDisabled,
+}: GraphModeSelectorProps) {
   return (
     <SpaceBetween gap={5}>
       <ModeButton
@@ -357,6 +363,7 @@ function GraphModeSelector({ mode, onChange }: GraphModeSelectorProps) {
       </ModeButton>
       <ModeButton
         selected={mode === 'budgeted'}
+        isDisabled={budgetedDisabled}
         onSelect={() => {
           onChange('budgeted');
         }}
@@ -460,9 +467,19 @@ function SankeyInner({ widget }: SankeyInnerProps) {
   const [earliestTransaction, setEarliestTransaction] = useState('');
   const [latestTransaction, setLatestTransaction] = useState('');
 
+  // Budgeted amounts are keyed by calendar month and don't exist while
+  // budgeting by pay period — the per-month `api/budget-month` requests
+  // reject and the report would hang empty. Fall back to Spent, and snap
+  // back if the cadence flips on while this report is open.
+  const payPeriodsBlockBudgetedMode = usePayPeriodConfig() != null;
   const [graphMode, setGraphMode] = useState<GraphMode>(
-    widget?.meta?.mode ?? 'spent',
+    payPeriodsBlockBudgetedMode ? 'spent' : (widget?.meta?.mode ?? 'spent'),
   );
+  useEffect(() => {
+    if (payPeriodsBlockBudgetedMode) {
+      setGraphMode('spent');
+    }
+  }, [payPeriodsBlockBudgetedMode]);
 
   const [topNcategories, settopNcategories] = useState<number>(
     widget?.meta?.topNcategories ?? 15,
@@ -829,7 +846,11 @@ function SankeyInner({ widget }: SankeyInnerProps) {
                 backgroundColor: theme.pillBorderDark,
               }}
             />
-            <GraphModeSelector mode={graphMode} onChange={setGraphMode} />
+            <GraphModeSelector
+              mode={graphMode}
+              onChange={setGraphMode}
+              budgetedDisabled={payPeriodsBlockBudgetedMode}
+            />
             <View
               style={{
                 width: 1,

--- a/packages/desktop-client/src/components/reports/reports/SankeyCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/SankeyCard.tsx
@@ -30,6 +30,7 @@ import type {
 import { useReport } from '#components/reports/useReport';
 import { useCategories } from '#hooks/useCategories';
 import { useLocale } from '#hooks/useLocale';
+import { usePayPeriodConfig } from '#hooks/usePayPeriodConfig';
 import { useResizeObserver } from '#hooks/useResizeObserver';
 
 type SankeyCardProps = {
@@ -51,7 +52,11 @@ export function SankeyCard({
     useCategories();
 
   const [start, end] = calculateTimeRange(meta?.timeFrame);
-  const mode = meta?.mode ?? 'spent';
+  // A widget saved in Budgeted mode has no data while budgeting by pay
+  // period (budgeted amounts are keyed by calendar month); fall back to
+  // Spent rather than issuing per-month requests that all reject.
+  const payPeriodConfig = usePayPeriodConfig();
+  const mode = payPeriodConfig != null ? 'spent' : (meta?.mode ?? 'spent');
 
   const [cardHeight, setCardHeight] = useState(0);
   const throttledSetCardHeight = useMemo(

--- a/packages/desktop-client/src/components/reports/reports/Spending.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Spending.tsx
@@ -38,6 +38,7 @@ import {
   getSpendingAverageRangeOptions,
   getSpendingAverageSummaryLabel,
   normalizeSpendingAverageRange,
+  resolveSpendingReportMode,
   spendingAverageRangeFromKey,
   spendingAverageRangeToKey,
 } from '#components/reports/spendingAverageRange';
@@ -48,6 +49,7 @@ import { useDashboardWidget } from '#hooks/useDashboardWidget';
 import { useFormat } from '#hooks/useFormat';
 import { useLocale } from '#hooks/useLocale';
 import { useNavigate } from '#hooks/useNavigate';
+import { usePayPeriodConfig } from '#hooks/usePayPeriodConfig';
 import { useRuleConditionFilters } from '#hooks/useRuleConditionFilters';
 import { useSyncedPref } from '#hooks/useSyncedPref';
 import { addNotification } from '#notifications/notificationsSlice';
@@ -96,7 +98,10 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
   const emptyIntervals: { name: string; pretty: string }[] = [];
   const [allIntervals, setAllIntervals] = useState(emptyIntervals);
 
-  const initialReportMode = widget?.meta?.mode ?? 'single-month';
+  // The "Budgeted" comparison reads calendar-month budgets, which don't
+  // exist while budgeting by pay period; see resolveSpendingReportMode.
+  const payPeriodsBlockBudgetMode = usePayPeriodConfig() != null;
+  const initialReportMode = resolveSpendingReportMode(widget?.meta?.mode);
   const [initialCompare, initialCompareTo] = calculateSpendingReportTimeRange(
     widget?.meta ?? {},
   );
@@ -367,17 +372,36 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
               >
                 <Trans>Single month</Trans>
               </ModeButton>
-              <ModeButton
-                selected={reportMode === 'budget'}
-                onSelect={() => {
-                  setReportMode('budget');
-                }}
+              <Tooltip
+                placement="top"
+                content={
+                  <Text>
+                    <Trans>
+                      Budgeted amounts aren&apos;t available while you budget by
+                      pay period
+                    </Trans>
+                  </Text>
+                }
                 style={{
-                  backgroundColor: 'inherit',
+                  ...styles.tooltip,
+                  lineHeight: 1.5,
+                  padding: '6px 10px',
                 }}
+                triggerProps={{ isDisabled: !payPeriodsBlockBudgetMode }}
               >
-                <Trans>Budgeted</Trans>
-              </ModeButton>
+                <ModeButton
+                  selected={reportMode === 'budget'}
+                  onSelect={() => {
+                    setReportMode('budget');
+                  }}
+                  isDisabled={payPeriodsBlockBudgetMode}
+                  style={{
+                    backgroundColor: 'inherit',
+                  }}
+                >
+                  <Trans>Budgeted</Trans>
+                </ModeButton>
+              </Tooltip>
               <ModeButton
                 selected={reportMode === 'average'}
                 onSelect={() => {

--- a/packages/desktop-client/src/components/reports/reports/Spending.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Spending.tsx
@@ -114,6 +114,15 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
 
   const [reportMode, setReportMode] = useState(initialReportMode);
 
+  // If pay periods switch on while this report is open (a sync from
+  // another device, or an undo), a selected Budgeted mode would keep
+  // plotting a flat zero; snap back to the single-month comparison.
+  useEffect(() => {
+    if (payPeriodsBlockBudgetMode && reportMode === 'budget') {
+      setReportMode('single-month');
+    }
+  }, [payPeriodsBlockBudgetMode, reportMode]);
+
   useEffect(() => {
     async function run() {
       const earliestTrans = await send('get-earliest-transaction');

--- a/packages/desktop-client/src/components/reports/reports/SpendingCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/SpendingCard.tsx
@@ -19,6 +19,7 @@ import { calculateSpendingReportTimeRange } from '#components/reports/reportRang
 import {
   getSpendingAverageRangeLabel,
   normalizeSpendingAverageRange,
+  resolveSpendingReportMode,
 } from '#components/reports/spendingAverageRange';
 import { createSpendingSpreadsheet } from '#components/reports/spreadsheets/spending-spreadsheet';
 import { useReport } from '#components/reports/useReport';
@@ -47,7 +48,7 @@ export function SpendingCard({
   const [isCardHovered, setIsCardHovered] = useState(false);
   const [nameMenuOpen, setNameMenuOpen] = useState(false);
 
-  const spendingReportMode = meta?.mode ?? 'single-month';
+  const spendingReportMode = resolveSpendingReportMode(meta?.mode);
   const averageRange = normalizeSpendingAverageRange(meta?.averageRange);
   const averageRangeLabel = getSpendingAverageRangeLabel(averageRange, t);
 

--- a/packages/desktop-client/src/components/reports/spendingAverageRange.ts
+++ b/packages/desktop-client/src/components/reports/spendingAverageRange.ts
@@ -1,5 +1,25 @@
 import * as monthUtils from '@actual-app/core/shared/months';
+import { payPeriodsActive } from '@actual-app/core/shared/pay-period-config';
 import type { SpendingAverageRange } from '@actual-app/core/types/models';
+
+export type SpendingReportMode = 'single-month' | 'budget' | 'average';
+
+/**
+ * The Spending report's "Budgeted" mode reads budgeted amounts keyed by
+ * calendar month, and no calendar-month budget exists while budgeting by
+ * pay period — the query comes back empty and the line plots as a flat
+ * zero. Everything else in this report is built from transactions and is
+ * unaffected, so fall back to the single-month comparison rather than
+ * blanking the whole report.
+ */
+export function resolveSpendingReportMode(
+  mode: SpendingReportMode | undefined,
+): SpendingReportMode {
+  if (mode === 'budget' && payPeriodsActive()) {
+    return 'single-month';
+  }
+  return mode ?? 'single-month';
+}
 
 export type SpendingAverageRangeKey =
   | 'last-3-months'

--- a/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.test.ts
@@ -1,6 +1,14 @@
+import {
+  resetPayPeriodConfigForTesting,
+  setPayPeriodConfig,
+} from '@actual-app/core/shared/pay-period-config';
 import type { CategoryEntity } from '@actual-app/core/types/models';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { isBaseCategory } from './budget-analysis-spreadsheet';
+import {
+  createBudgetAnalysisSpreadsheet,
+  isBaseCategory,
+} from './budget-analysis-spreadsheet';
 
 const makeCategory = (
   overrides: Partial<CategoryEntity> & Pick<CategoryEntity, 'id' | 'name'>,
@@ -73,5 +81,31 @@ describe('createBudgetAnalysisSpreadsheet', () => {
       expect(result).toContain(visibleExpense);
       expect(result).toContain(hiddenExpense);
     });
+  });
+});
+
+describe('createBudgetAnalysisSpreadsheet while budgeting by pay period', () => {
+  afterEach(() => {
+    resetPayPeriodConfigForTesting();
+  });
+
+  it('leaves the data unset instead of charting empty calendar months', async () => {
+    setPayPeriodConfig({ payFrequency: 'biweekly', startDate: '2024-01-05' });
+
+    const setData = vi.fn();
+    const run = createBudgetAnalysisSpreadsheet({
+      startDate: '2024-01-01',
+      endDate: '2024-03-31',
+    });
+
+    // `send` and the spreadsheet are unmocked, so reaching either would
+    // fail: this asserts the report bails out before requesting a single
+    // calendar month's budget.
+    await run(
+      undefined as unknown as Parameters<typeof run>[0],
+      setData as unknown as Parameters<typeof run>[1],
+    );
+
+    expect(setData).not.toHaveBeenCalled();
   });
 });

--- a/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.ts
@@ -1,6 +1,7 @@
 // @ts-strict-ignore
 import { send } from '@actual-app/core/platform/client/connection';
 import * as monthUtils from '@actual-app/core/shared/months';
+import { payPeriodsActive } from '@actual-app/core/shared/pay-period-config';
 import type {
   CategoryEntity,
   RuleConditionEntity,
@@ -54,6 +55,15 @@ export function createBudgetAnalysisSpreadsheet({
     spreadsheet: ReturnType<typeof useSpreadsheet>,
     setData: (data: BudgetAnalysisData) => void,
   ) => {
+    // This report reads budgeted amounts per calendar month, and those
+    // columns don't exist while the budget is kept in pay periods. Asking
+    // for them would report zeros and leave a placeholder cell behind for
+    // every month, so leave the data unset — the report renders
+    // `BudgetDataUnavailable` in this case.
+    if (payPeriodsActive()) {
+      return;
+    }
+
     // Get all categories
     const { list: allCategories, grouped: allCategoryGroups } =
       await send('get-categories');

--- a/packages/desktop-client/src/components/reports/spreadsheets/budgetDataQuery.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budgetDataQuery.test.ts
@@ -1,11 +1,18 @@
+import {
+  resetPayPeriodConfigForTesting,
+  setPayPeriodConfig,
+} from '@actual-app/core/shared/pay-period-config';
 import type {
   CategoryEntity,
   CategoryGroupEntity,
   RuleConditionEntity,
 } from '@actual-app/core/types/models';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
-import { filterCategoriesByConditions } from './budgetDataQuery';
+import {
+  fetchBudgetData,
+  filterCategoriesByConditions,
+} from './budgetDataQuery';
 
 const categoryGroups = [
   { id: 'group-bills', name: 'Bills' },
@@ -98,5 +105,28 @@ describe('filterCategoriesByConditions', () => {
     );
 
     expect(result.map(category => category.id)).toEqual(['cat-dining']);
+  });
+});
+
+describe('fetchBudgetData while budgeting by pay period', () => {
+  afterEach(() => {
+    resetPayPeriodConfigForTesting();
+  });
+
+  it('returns no data instead of querying calendar months', async () => {
+    setPayPeriodConfig({ payFrequency: 'biweekly', startDate: '2024-01-05' });
+
+    const result = await fetchBudgetData({
+      startDate: '2024-01-01',
+      endDate: '2024-03-31',
+      interval: 'Monthly',
+      categories,
+      categoryGroups,
+    });
+
+    // Budgeted amounts live in pay period columns, so there is nothing to
+    // report for these months. Crucially the months are never requested:
+    // `send` is unmocked here, so any attempt would reject.
+    expect(result).toEqual({ assets: [], debts: [] });
   });
 });

--- a/packages/desktop-client/src/components/reports/spreadsheets/budgetDataQuery.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budgetDataQuery.ts
@@ -1,5 +1,6 @@
 import { send } from '@actual-app/core/platform/client/connection';
 import * as monthUtils from '@actual-app/core/shared/months';
+import { payPeriodsActive } from '@actual-app/core/shared/pay-period-config';
 import type { Handlers } from '@actual-app/core/types/handlers';
 import type {
   CategoryEntity,
@@ -206,6 +207,15 @@ export async function fetchBudgetData({
     conditions,
     conditionsOp,
   );
+
+  // Budgeted amounts live in pay period columns while pay periods are
+  // active, so the calendar months below have no budget to report. Asking
+  // for them anyway wouldn't just return empty values — the spreadsheet
+  // creates a placeholder cell for every month it is asked about — so bail
+  // out instead. Callers render `BudgetDataUnavailable` for this case.
+  if (payPeriodsActive()) {
+    return { assets: [], debts: [] };
+  }
 
   const months = monthUtils.rangeInclusive(
     monthUtils.getMonth(startDate),

--- a/packages/desktop-client/src/components/settings/PayPeriodSettings.tsx
+++ b/packages/desktop-client/src/components/settings/PayPeriodSettings.tsx
@@ -31,6 +31,13 @@ export function PayPeriodSettings() {
   // without this the controls would just look frozen for several seconds.
   const [isSaving, setIsSaving] = useState(false);
 
+  // The payday date is committed on blur/Enter, not per keystroke: a native
+  // date input emits a change for every completed segment ('0002-01-05',
+  // '0020-01-05', … while the year is typed), and each one is a "valid"
+  // config — so saving on change kicked off a full budget rebuild per
+  // keystroke and the `isSaving` disable blurred the field mid-typing.
+  const [pendingStartDate, setPendingStartDate] = useState<string | null>(null);
+
   const isEnabled = String(showPayPeriods) === 'true';
   const validConfig = validatePayPeriodConfig({
     payFrequency: payPeriodFrequency,
@@ -57,6 +64,19 @@ export function PayPeriodSettings() {
     // whenever the active pay period configuration changes (see
     // loot-core server/budget/pay-period-config.ts).
     void savePref({ showPayPeriods: isEnabled ? 'false' : 'true' });
+  };
+
+  const commitStartDate = () => {
+    if (pendingStartDate == null) {
+      return;
+    }
+    const nextValue = pendingStartDate;
+    setPendingStartDate(null);
+    // A native date input only produces '' or a complete yyyy-MM-dd, so a
+    // non-empty changed value is a finished entry.
+    if (nextValue && nextValue !== (payPeriodStartDate ?? '')) {
+      void savePref({ payPeriodStartDate: nextValue });
+    }
   };
 
   return (
@@ -90,11 +110,11 @@ export function PayPeriodSettings() {
               <Input
                 id="pay-period-start-date"
                 type="date"
-                value={payPeriodStartDate ?? ''}
+                value={pendingStartDate ?? payPeriodStartDate ?? ''}
                 disabled={isSaving}
-                onChangeValue={newValue =>
-                  void savePref({ payPeriodStartDate: newValue })
-                }
+                onChangeValue={setPendingStartDate}
+                onBlur={commitStartDate}
+                onEnter={commitStartDate}
               />
             </FormField>
           </View>

--- a/packages/desktop-client/src/components/settings/PayPeriodSettings.tsx
+++ b/packages/desktop-client/src/components/settings/PayPeriodSettings.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
+import { AnimatedLoading } from '@actual-app/components/icons/AnimatedLoading';
 import { Input } from '@actual-app/components/input';
 import { Select } from '@actual-app/components/select';
 import { Text } from '@actual-app/components/text';
@@ -8,19 +9,27 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import { validatePayPeriodConfig } from '@actual-app/core/shared/pay-periods';
 import type { PayFrequency } from '@actual-app/core/shared/pay-periods';
+import type { SyncedPrefs } from '@actual-app/core/types/prefs';
 
 import { Checkbox, FormField, FormLabel } from '#components/forms';
 import { useSyncedPref } from '#hooks/useSyncedPref';
+import { saveSyncedPrefs } from '#prefs/prefsSlice';
+import { useDispatch } from '#redux';
 
 import { Setting } from './UI';
 
 export function PayPeriodSettings() {
   const { t } = useTranslation();
-  const [showPayPeriods, setShowPayPeriods] = useSyncedPref('showPayPeriods');
-  const [payPeriodFrequency, setPayPeriodFrequency] =
-    useSyncedPref('payPeriodFrequency');
-  const [payPeriodStartDate, setPayPeriodStartDate] =
-    useSyncedPref('payPeriodStartDate');
+  const dispatch = useDispatch();
+  const [showPayPeriods] = useSyncedPref('showPayPeriods');
+  const [payPeriodFrequency] = useSyncedPref('payPeriodFrequency');
+  const [payPeriodStartDate] = useSyncedPref('payPeriodStartDate');
+
+  // Every one of these prefs can change the active pay period
+  // configuration, and doing so rebuilds every budget sheet from scratch
+  // before the save resolves. Mutators are serialized server-side, so
+  // without this the controls would just look frozen for several seconds.
+  const [isSaving, setIsSaving] = useState(false);
 
   const isEnabled = String(showPayPeriods) === 'true';
   const validConfig = validatePayPeriodConfig({
@@ -34,11 +43,20 @@ export function PayPeriodSettings() {
     ['monthly', t('Monthly')],
   ];
 
+  async function savePref(prefs: SyncedPrefs) {
+    setIsSaving(true);
+    try {
+      await dispatch(saveSyncedPrefs({ prefs }));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
   const onToggle = () => {
     // Saving the pref is enough: the server rebuilds the budget sheets
     // whenever the active pay period configuration changes (see
     // loot-core server/budget/pay-period-config.ts).
-    setShowPayPeriods(isEnabled ? 'false' : 'true');
+    void savePref({ showPayPeriods: isEnabled ? 'false' : 'true' });
   };
 
   return (
@@ -56,9 +74,10 @@ export function PayPeriodSettings() {
                 options={frequencyOptions}
                 value={(payPeriodFrequency ?? '') as PayFrequency | ''}
                 defaultLabel={t('Choose a frequency')}
+                disabled={isSaving}
                 onChange={newValue => {
                   if (newValue) {
-                    setPayPeriodFrequency(newValue);
+                    void savePref({ payPeriodFrequency: newValue });
                   }
                 }}
               />
@@ -72,22 +91,38 @@ export function PayPeriodSettings() {
                 id="pay-period-start-date"
                 type="date"
                 value={payPeriodStartDate ?? ''}
-                onChangeValue={newValue => setPayPeriodStartDate(newValue)}
+                disabled={isSaving}
+                onChangeValue={newValue =>
+                  void savePref({ payPeriodStartDate: newValue })
+                }
               />
             </FormField>
           </View>
 
-          <Text style={{ display: 'flex' }}>
-            <Checkbox
-              id="settings-showPayPeriods"
-              checked={isEnabled}
-              disabled={!isEnabled && !validConfig}
-              onChange={onToggle}
-            />
-            <label htmlFor="settings-showPayPeriods">
-              <Trans>Budget by pay period</Trans>
-            </label>
-          </Text>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+            <Text style={{ display: 'flex' }}>
+              <Checkbox
+                id="settings-showPayPeriods"
+                checked={isEnabled}
+                disabled={isSaving || (!isEnabled && !validConfig)}
+                onChange={onToggle}
+              />
+              <label htmlFor="settings-showPayPeriods">
+                <Trans>Budget by pay period</Trans>
+              </label>
+            </Text>
+            {isSaving && (
+              <View
+                style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}
+                aria-live="polite"
+              >
+                <AnimatedLoading width={14} height={14} />
+                <Text style={{ color: theme.pageTextSubdued }}>
+                  <Trans>Rebuilding your budget…</Trans>
+                </Text>
+              </View>
+            )}
+          </View>
 
           {!validConfig && (
             <Text style={{ color: theme.warningText }}>

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -1825,7 +1825,10 @@ const Transaction = memo(function Transaction({
             }) => (
               <SheetNameProvider
                 name={monthUtils.sheetForMonth(
-                  monthUtils.monthFromDate(transaction.date),
+                  // The budget column owning this date, which is a pay
+                  // period rather than a calendar month when pay periods
+                  // are active.
+                  monthUtils.budgetMonthFromDate(transaction.date),
                 )}
               >
                 <CategoryAutocomplete

--- a/packages/desktop-client/src/hooks/useCategoryScheduleGoalTemplateIndicator.ts
+++ b/packages/desktop-client/src/hooks/useCategoryScheduleGoalTemplateIndicator.ts
@@ -56,7 +56,13 @@ export function useCategoryScheduleGoalTemplateIndicator({
         return status === 'upcoming' || status === 'due' || status === 'missed';
       })
       .filter(schedule => {
-        if (monthUtils.monthFromDate(schedule.next_date) === month) {
+        // `month` is a budget column, which is a pay period rather than a
+        // calendar month while pay periods are active — so route the dates
+        // to their containing column instead of their calendar month, or
+        // the comparison never matches and the indicator disappears
+        // entirely. `budgetMonthFromDate` is the calendar month when pay
+        // periods are off.
+        if (monthUtils.budgetMonthFromDate(schedule.next_date) === month) {
           return true;
         }
 
@@ -64,7 +70,7 @@ export function useCategoryScheduleGoalTemplateIndicator({
           schedule.next_date,
           upcomingDays,
         );
-        return monthUtils.monthFromDate(indicatorStartDate) === month;
+        return monthUtils.budgetMonthFromDate(indicatorStartDate) === month;
       })
       .sort((a, b) => {
         // Display missed schedules first, then due, then upcoming.

--- a/packages/desktop-client/src/hooks/useFormulaExecution.ts
+++ b/packages/desktop-client/src/hooks/useFormulaExecution.ts
@@ -7,6 +7,7 @@ import {
 } from '@actual-app/core/shared/formulas/customFunctions';
 import type { FormulaQueryContext } from '@actual-app/core/shared/formulas/customFunctions';
 import * as monthUtils from '@actual-app/core/shared/months';
+import { payPeriodsActive } from '@actual-app/core/shared/pay-period-config';
 import { q } from '@actual-app/core/shared/query';
 import type { Query } from '@actual-app/core/shared/query';
 import { integerToAmount } from '@actual-app/core/shared/util';
@@ -571,6 +572,16 @@ async function fetchBudgetDimensionValueDirect(
   const dim = dimension.toLowerCase();
   if (!allowed.has(dim)) {
     throw new Error(`Invalid BUDGET_QUERY dimension: ${dimension}`);
+  }
+
+  // Budgeted amounts are stored against pay period columns while pay
+  // periods are active, so the calendar months below have nothing to read.
+  // Report that rather than summing a column of zeros into a total that
+  // looks real.
+  if (payPeriodsActive()) {
+    throw new Error(
+      'BUDGET_QUERY is not available while budgeting by pay period',
+    );
   }
 
   const intervals = monthUtils.rangeInclusive(startMonth, endMonth);

--- a/packages/desktop-client/src/hooks/usePayPeriodConfig.ts
+++ b/packages/desktop-client/src/hooks/usePayPeriodConfig.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 
+import { listen } from '@actual-app/core/platform/client/connection';
 import {
   getPayPeriodConfig,
   setPayPeriodConfig,
@@ -7,7 +8,11 @@ import {
 import { validatePayPeriodConfig } from '@actual-app/core/shared/pay-periods';
 import type { PayPeriodConfig } from '@actual-app/core/shared/pay-periods';
 
+import { loadPrefs } from '#prefs/prefsSlice';
+import { useDispatch } from '#redux';
+
 import { useFeatureFlag } from './useFeatureFlag';
+import { useSpreadsheet } from './useSpreadsheet';
 import { useSyncedPref } from './useSyncedPref';
 
 /**
@@ -28,8 +33,13 @@ export function usePayPeriodConfig(): PayPeriodConfig | null {
   return validatePayPeriodConfig({ payFrequency, startDate });
 }
 
-function configKey(config: PayPeriodConfig | null): string | null {
-  return config ? `${config.payFrequency}|${config.startDate}` : null;
+/**
+ * A stable identity for a pay period configuration, suitable as an effect
+ * dependency: it changes whenever the budget cadence changes, including
+ * when pay periods are switched off entirely.
+ */
+export function payPeriodConfigKey(config: PayPeriodConfig | null): string {
+  return config ? `${config.payFrequency}|${config.startDate}` : 'calendar';
 }
 
 /**
@@ -39,13 +49,29 @@ function configKey(config: PayPeriodConfig | null): string | null {
  */
 export function usePayPeriodConfigSync(): void {
   const config = usePayPeriodConfig();
+  const dispatch = useDispatch();
+  const spreadsheet = useSpreadsheet();
 
   // Update during render (idempotent) so components rendering in the
   // same pass — before effects run — already resolve pay period IDs
   // against the fresh config.
-  if (configKey(config) !== configKey(getPayPeriodConfig())) {
+  if (payPeriodConfigKey(config) !== payPeriodConfigKey(getPayPeriodConfig())) {
     setPayPeriodConfig(config);
   }
+
+  useEffect(() => {
+    // Synced prefs sync under the `preferences` dataset, which the generic
+    // prefs reload in sync-events doesn't watch, so a configuration change
+    // this client didn't initiate (another device or tab, or an undo)
+    // would never reach redux. The server announces those explicitly.
+    return listen('pay-period-config-changed', () => {
+      // Order matters: the cached values belong to the previous cadence
+      // and sheet names collide across cadences, so they have to go
+      // before the prefs reload re-renders the budget against the new one.
+      spreadsheet.clearCache();
+      void dispatch(loadPrefs());
+    });
+  }, [dispatch, spreadsheet]);
 
   useEffect(() => {
     // Deactivate when the budget file is closed; the next file's prefs

--- a/packages/desktop-client/src/hooks/useSpreadsheet.tsx
+++ b/packages/desktop-client/src/hooks/useSpreadsheet.tsx
@@ -62,6 +62,20 @@ function makeSpreadsheet() {
       LRUValueCache.set(name, value);
     }
 
+    /**
+     * Drops every cached cell value. Needed when the meaning of a sheet
+     * name changes underneath us: pay period sheet names collide across
+     * cadences (`2026-13` exists under every frequency), so a value
+     * cached for the previous configuration would otherwise be rendered
+     * synchronously at bind time as if it were current.
+     */
+    clearCache(): void {
+      LRUValueCache.clear();
+      for (const name of Object.keys(cellCache)) {
+        delete cellCache[name];
+      }
+    }
+
     listen(): () => void {
       return listen('cells-changed', event => {
         if (!observersDisabled) {

--- a/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
+++ b/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
@@ -228,14 +228,18 @@ export function useTransactionBatchActions() {
     };
 
     const pushCategoryAutocompleteModal = () => {
-      // Only show balances when all selected transaction are in the same month.
+      // Only show balances when all selected transactions fall in the same
+      // budget column. The modal turns this into a sheet name, so it has to
+      // be the pay period while pay periods are active — a calendar month
+      // would name a sheet that doesn't exist and every balance would read
+      // as zero. `budgetMonthFromDate` is the calendar month when they're off.
       const transactionMonth = transactions[0]?.date
-        ? monthUtils.monthFromDate(transactions[0]?.date)
+        ? monthUtils.budgetMonthFromDate(transactions[0]?.date)
         : null;
       const transactionsHaveSameMonth =
         transactionMonth &&
         transactions.every(
-          t => monthUtils.monthFromDate(t.date) === transactionMonth,
+          t => monthUtils.budgetMonthFromDate(t.date) === transactionMonth,
         );
       dispatch(
         pushModal({

--- a/packages/desktop-client/src/spreadsheet/bindings.ts
+++ b/packages/desktop-client/src/spreadsheet/bindings.ts
@@ -1,3 +1,5 @@
+import { getPayPeriodConfig } from '@actual-app/core/shared/pay-period-config';
+import { getPayPeriodDateFilter } from '@actual-app/core/shared/pay-periods';
 import { q } from '@actual-app/core/shared/query';
 import type {
   AccountEntity,
@@ -85,6 +87,15 @@ export function closedAccountBalance() {
   } satisfies Binding<'account', 'closed-accounts-balance'>;
 }
 
+// A budget column is a calendar month or, when pay periods are active, a
+// pay period whose day range doesn't line up with any month — so the
+// `$month` transform can never match a pay period ID. Bindings aren't
+// React, so the active config comes from the shared registry rather than
+// the usePayPeriodConfig hook.
+function budgetMonthDateFilter(month: string) {
+  return getPayPeriodDateFilter(month, getPayPeriodConfig());
+}
+
 export function categoryBalance(
   categoryId: CategoryEntity['id'],
   month: string,
@@ -94,7 +105,7 @@ export function categoryBalance(
     query: q('transactions')
       .filter({
         category: categoryId,
-        date: { $transform: '$month', $eq: month },
+        date: budgetMonthDateFilter(month),
       })
       .options({ splits: 'inline' })
       .calculate({ $sum: '$amount' }),
@@ -110,7 +121,7 @@ export function categoryBalanceCleared(
     query: q('transactions')
       .filter({
         category: categoryId,
-        date: { $transform: '$month', $eq: month },
+        date: budgetMonthDateFilter(month),
         cleared: true,
       })
       .options({ splits: 'inline' })
@@ -127,7 +138,7 @@ export function categoryBalanceUncleared(
     query: q('transactions')
       .filter({
         category: categoryId,
-        date: { $transform: '$month', $eq: month },
+        date: budgetMonthDateFilter(month),
         cleared: false,
       })
       .options({ splits: 'inline' })

--- a/packages/docs/docs-sidebar.js
+++ b/packages/docs/docs-sidebar.js
@@ -111,6 +111,7 @@ const sidebars = {
           },
           items: [
             'budgeting/categories',
+            'budgeting/pay-periods',
             'budgeting/returns-and-reimbursements',
             {
               type: 'category',

--- a/packages/docs/docs/api/reference.md
+++ b/packages/docs/docs/api/reference.md
@@ -138,6 +138,8 @@ These are types.
 
 ## Budgets
 
+If the budget file uses [pay periods](../budgeting/pay-periods.md), these methods work with pay period identifiers such as `2026-13` instead of calendar months, so pass values returned by `getBudgetMonths` rather than month strings you build yourself.
+
 #### `getBudgetMonths`
 
 <Method name="getBudgetMonths" args={[]}  returns="Promise<month[]>" />

--- a/packages/docs/docs/budgeting/pay-periods.md
+++ b/packages/docs/docs/budgeting/pay-periods.md
@@ -41,7 +41,7 @@ The pay frequency decides how long a column is, and the payday date decides wher
 
 Columns always sit right next to each other with no gaps and no overlaps, so every day belongs to exactly one column.
 
-Each column is labeled with its date range and its position in the year, so the first period of the year appears as something like _Jan 5 - Jan 18 (PP1)_, the second as _Jan 19 - Feb 1 (PP2)_, and so on.
+Each column is labeled with its date range, so the first period of the year appears as something like _Jan 5 - Jan 18_ and the second as _Jan 19 - Feb 1_. The compact month picker above the desktop budget shortens each period to a letter and a number — _J1_ for the first period starting in January, _F1_ for the first starting in February — and a few places, like the column's menu, add the period's position in the year as _(PP1)_, _(PP2)_ and so on.
 
 ### How Periods Are Numbered
 
@@ -63,11 +63,11 @@ Amounts you budget while **Budget by pay period** is on are not visible when you
 
 Nothing is deleted when you switch. Each mode simply keeps its own set of budget columns, so whatever you budgeted in the other mode is waiting for you if you switch back. But you can't budget in one mode and read the results in the other, and switching back and forth means maintaining two budgets.
 
-Your transactions, account balances and category balances are shared between both modes — it is only the budgeted amounts that are separate.
+Your transactions and account balances are shared between both modes. Category balances are not: a category's balance is worked out per column from what you budgeted and spent there, and since the budgeted amounts are separate in each mode, the balances are too.
 
 ### Changing the Cadence Rebuilds Your Columns
 
-If you change the pay frequency or the payday date while pay periods are on, Actual rebuilds your budget columns to match the new schedule. The new columns cover different date ranges than the old ones, so amounts you budgeted against the old schedule won't line up with the new columns and you will need to go back through and budget again.
+If you change the pay frequency or the payday date while pay periods are on, Actual rebuilds your budget columns to match the new schedule. The stored amounts keep their period numbers, but those numbers now describe different date ranges — the amount you put into "the two weeks starting January 6" reappears in "the week starting January 1", and amounts in periods past the new schedule's count (a weekly year has more periods than a monthly one) stop being shown at all. Check your budget after a cadence change and expect to budget again.
 
 :::caution
 Settle on your pay frequency and payday date before you spend time budgeting. Changing them later means redoing that work.
@@ -78,8 +78,9 @@ Settle on your pay frequency and payday date before you spend time budgeting. Ch
 While you are budgeting by pay period, reports that read budgeted amounts can't be drawn. That means:
 
 - The [Budget Analysis](../experimental/budget-analysis-report.md) card has no data to show.
-- A [custom report](../reports/custom-reports.md) using the **Budgeted** balance type has no data to show.
+- A [custom report](../reports/custom-reports.md) using the **Budgeted** balance type has no data to show, on the full report page and on a saved dashboard card alike.
 - The Spending report's **Budgeted** comparison is unavailable; its **Single month** and **Average** comparisons work normally.
+- The Sankey report's **Budgeted** view falls back to **Spent** while pay periods are on.
 
 Reports built from your transactions — spending, net worth, cash flow, income vs expenses and the rest — are unaffected and keep working normally.
 
@@ -93,11 +94,13 @@ So a $1,200 rent payment due on the 1st is funded in full in the period containi
 
 Templates keep their calendar wording whatever your pay cycle is. A goal is written as "by August", "every 2 months" or "$50 a week", and the target month picker offers calendar months only — there's no way to aim a goal at a specific pay period.
 
-Actual converts those windows into pay periods for you, so the saving is spread across the periods you actually have:
+The one deliberate exception is a plain fixed amount. `#template 50` budgets $50 into **every** budget column, so with pay periods on it behaves as _$50 per paycheck_ — about $108 a month on a two-week cycle — not $50 a month. If you want the same monthly total after switching, divide your fixed templates by the number of paychecks in a month.
+
+Everything that describes a _window of time_ is converted into pay periods for you:
 
 - **Save by a month.** A goal due by August is funded across every period between now and the end of August, so each paycheck sets aside a smaller amount than a monthly budget would.
 - **Repeating amounts.** "$25 every week" budgets the occurrences that fall inside each period — usually one — rather than the whole month's worth in every period.
-- **Spending limits.** An `up to` limit is scaled to the period: a weekly limit counts the weeks inside that period, and a daily limit counts its days.
+- **Spending limits.** An `up to` limit is a cap on a stretch of time, so it is scaled to the column: a daily limit counts the column's days, a weekly limit counts its weeks, and a monthly limit is reduced to the column's share of a month — `up to 600` caps a two-week column at roughly $276, keeping the monthly total honest. Note the contrast with fixed amounts above: a cap is a monthly total, a fixed template is an amount per paycheck.
 
 ### Switching Modes Takes a Moment
 
@@ -112,7 +115,7 @@ Pay periods share the same identifier format as calendar months, `YYYY-MM`, but 
 While pay periods are on, this changes what the budget methods expect and return:
 
 - [`getBudgetMonths()`](../api/reference.md#getbudgetmonths) returns pay period identifiers such as `2026-13`, not calendar months such as `2026-01`.
-- [`getBudgetMonth()`](../api/reference.md#getbudgetmonth) and the other budget methods only accept those same pay period identifiers. Passing a calendar month raises an error, because no budget column exists for it.
+- [`getBudgetMonth()`](../api/reference.md#getbudgetmonth) and the other budget methods only accept those same pay period identifiers. Passing a calendar month raises an error, because no budget column exists for it. (The one exception is a running import, which skips this check.)
 
 The fix is the same in every case: have your script use the values that `getBudgetMonths()` gives back, rather than building month strings itself.
 
@@ -123,7 +126,7 @@ const latest = months[months.length - 1];
 const budget = await api.getBudgetMonth(latest);
 
 // Breaks when the budget uses pay periods
-const budget = await api.getBudgetMonth('2026-01');
+const badBudget = await api.getBudgetMonth('2026-01');
 ```
 
 If a script has to work with real dates, read the identifiers from `getBudgetMonths()` and pick the one you need, instead of formatting a date into `YYYY-MM` yourself.

--- a/packages/docs/docs/budgeting/pay-periods.md
+++ b/packages/docs/docs/budgeting/pay-periods.md
@@ -79,6 +79,7 @@ While you are budgeting by pay period, reports that read budgeted amounts can't 
 
 - The [Budget Analysis](../experimental/budget-analysis-report.md) card has no data to show.
 - A [custom report](../reports/custom-reports.md) using the **Budgeted** balance type has no data to show.
+- The Spending report's **Budgeted** comparison is unavailable; its **Single month** and **Average** comparisons work normally.
 
 Reports built from your transactions — spending, net worth, cash flow, income vs expenses and the rest — are unaffected and keep working normally.
 
@@ -87,6 +88,16 @@ Reports built from your transactions — spending, net worth, cash flow, income 
 If you use a [goal template](../experimental/goal-templates.md) based on a schedule, and that schedule repeats monthly, the whole amount is budgeted in the single pay period that the bill actually falls in. The earlier periods of that month set nothing aside for it.
 
 So a $1,200 rent payment due on the 1st is funded in full in the period containing the 1st, rather than being spread across the two or three periods that make up the month. If you would rather build the money up over several paychecks, budget for it manually instead of relying on the template.
+
+### Goal Templates Still Speak in Calendar Months
+
+Templates keep their calendar wording whatever your pay cycle is. A goal is written as "by August", "every 2 months" or "$50 a week", and the target month picker offers calendar months only — there's no way to aim a goal at a specific pay period.
+
+Actual converts those windows into pay periods for you, so the saving is spread across the periods you actually have:
+
+- **Save by a month.** A goal due by August is funded across every period between now and the end of August, so each paycheck sets aside a smaller amount than a monthly budget would.
+- **Repeating amounts.** "$25 every week" budgets the occurrences that fall inside each period — usually one — rather than the whole month's worth in every period.
+- **Spending limits.** An `up to` limit is scaled to the period: a weekly limit counts the weeks inside that period, and a daily limit counts its days.
 
 ### Switching Modes Takes a Moment
 

--- a/packages/docs/docs/budgeting/pay-periods.md
+++ b/packages/docs/docs/budgeting/pay-periods.md
@@ -1,0 +1,118 @@
+# Pay Periods
+
+<ExperimentalFeatureWarning />
+
+## What Pay Periods Are
+
+Actual normally gives you one budget column per calendar month. **Pay periods** replace those columns with columns that follow your own pay schedule, so a column covers the stretch of time between one payday and the next.
+
+This helps if the calendar month isn't the rhythm your money actually moves in. Some examples:
+
+- You are paid every two weeks, so some months contain three paychecks and others contain two. Budgeting a single monthly amount hides that difference.
+- You are paid weekly and would rather decide what each paycheck has to cover than plan a whole month at once.
+- Your rent, loan payments or other big bills are due right after a payday, and you want each paycheck's column to show what is left once those bills are covered.
+
+Everything else in Actual works the way it always has. Transactions, accounts, categories, rules and schedules are unchanged — the only thing that changes is what a budget column represents. Instead of _January_, a column might be _Jan 5 - Jan 18_.
+
+If your pay lines up reasonably well with calendar months already, you probably don't need this feature.
+
+## Turning On Pay Periods
+
+Pay periods are an experimental feature, so there are two steps: switch on the feature flag, then configure it.
+
+1. In the sidebar, click **Settings**, then **Show advanced settings**, then open **Experimental features**.
+2. Click **I understand the risks, show experimental features** if you haven't already agreed to the disclaimer. See [Experimental Features](../experimental/index.md) for more about how these features work.
+3. Tick **Pay periods**.
+4. Go back to the main **Settings** page. There is now a **Pay periods** section.
+5. Choose your **Pay frequency**: **Weekly**, **Every 2 weeks** or **Monthly**.
+6. In **Date of a payday**, enter the date of any one of your paydays. It does not have to be the first one, or a recent one — one real payday is enough.
+7. Tick **Budget by pay period**.
+
+The **Budget by pay period** checkbox stays disabled until both the pay frequency and the payday date are filled in, because Actual can't work out where your periods start without them. A message under the checkbox tells you when something is still missing.
+
+Once the box is ticked, Actual rebuilds your budget columns and the budget page starts showing pay periods instead of months. To go back to calendar months, untick **Budget by pay period**.
+
+## How Your Choices Shape the Columns
+
+The pay frequency decides how long a column is, and the payday date decides where the columns fall.
+
+- **Weekly** gives you a new column every 7 days, and **Every 2 weeks** gives you a new column every 14 days, counted out from the payday date you entered. If you tell Actual about a payday on a Friday, every period will begin on a Friday.
+- **Monthly** gives you one column per calendar month, but starting on the day of the month you entered rather than on the 1st. If your payday is on the 25th, your columns run from the 25th to the 24th. For a day that some months don't have, Actual uses the last day of the shorter month instead — a payday on the 31st means the February column starts on the 28th, or the 29th in a leap year.
+
+Columns always sit right next to each other with no gaps and no overlaps, so every day belongs to exactly one column.
+
+Each column is labeled with its date range and its position in the year, so the first period of the year appears as something like _Jan 5 - Jan 18 (PP1)_, the second as _Jan 19 - Feb 1 (PP2)_, and so on.
+
+### How Periods Are Numbered
+
+Periods are numbered within each calendar year. The first period of a year is the first one that _begins_ in January of that year, and numbering carries on from there — so the count restarts at 1 every January, no matter which payday date you entered.
+
+Because a period doesn't have to stop at the end of the year, a period that begins in late December can run on into the first days of January. Those January days belong to that December period, which is the last period of the old year rather than the first period of the new one.
+
+:::note
+Changing the payday date to a different date shifts where your columns fall, even if you keep the same pay frequency. Pick a date that reflects your real pay schedule and then leave it alone. See the limitations below for what happens to amounts you have already budgeted.
+:::
+
+## Known Limitations
+
+Pay periods are still under development, and there are some rough edges worth knowing about before you switch your budget over.
+
+### Pay Period and Calendar Month Budgets Are Kept Separately
+
+Amounts you budget while **Budget by pay period** is on are not visible when you switch back to calendar months, and amounts you budgeted in calendar months are not visible while you are budgeting by pay period. There is no conversion between the two.
+
+Nothing is deleted when you switch. Each mode simply keeps its own set of budget columns, so whatever you budgeted in the other mode is waiting for you if you switch back. But you can't budget in one mode and read the results in the other, and switching back and forth means maintaining two budgets.
+
+Your transactions, account balances and category balances are shared between both modes — it is only the budgeted amounts that are separate.
+
+### Changing the Cadence Rebuilds Your Columns
+
+If you change the pay frequency or the payday date while pay periods are on, Actual rebuilds your budget columns to match the new schedule. The new columns cover different date ranges than the old ones, so amounts you budgeted against the old schedule won't line up with the new columns and you will need to go back through and budget again.
+
+:::caution
+Settle on your pay frequency and payday date before you spend time budgeting. Changing them later means redoing that work.
+:::
+
+### Budget-Based Reports Are Not Available
+
+While you are budgeting by pay period, reports that read budgeted amounts can't be drawn. That means:
+
+- The [Budget Analysis](../experimental/budget-analysis-report.md) card has no data to show.
+- A [custom report](../reports/custom-reports.md) using the **Budgeted** balance type has no data to show.
+
+Reports built from your transactions — spending, net worth, cash flow, income vs expenses and the rest — are unaffected and keep working normally.
+
+### Monthly Schedule Templates Fund the Bill in One Period
+
+If you use a [goal template](../experimental/goal-templates.md) based on a schedule, and that schedule repeats monthly, the whole amount is budgeted in the single pay period that the bill actually falls in. The earlier periods of that month set nothing aside for it.
+
+So a $1,200 rent payment due on the 1st is funded in full in the period containing the 1st, rather than being spread across the two or three periods that make up the month. If you would rather build the money up over several paychecks, budget for it manually instead of relying on the template.
+
+### Switching Modes Takes a Moment
+
+Ticking or unticking **Budget by pay period** rebuilds every budget column, which can take a few seconds on a large budget. Actual shows a **Rebuilding your budget…** message while it works, and the settings controls are unavailable until it finishes. Let it complete rather than reloading the page.
+
+## Pay Periods and the API
+
+This section only matters if you use the [`@actual-app/api` package](../api/index.md) or scripts built on it. If you don't, you can stop reading here.
+
+Pay periods share the same identifier format as calendar months, `YYYY-MM`, but they continue past month 12 — the first pay period of 2026 is `2026-13`, the second is `2026-14`, and so on.
+
+While pay periods are on, this changes what the budget methods expect and return:
+
+- [`getBudgetMonths()`](../api/reference.md#getbudgetmonths) returns pay period identifiers such as `2026-13`, not calendar months such as `2026-01`.
+- [`getBudgetMonth()`](../api/reference.md#getbudgetmonth) and the other budget methods only accept those same pay period identifiers. Passing a calendar month raises an error, because no budget column exists for it.
+
+The fix is the same in every case: have your script use the values that `getBudgetMonths()` gives back, rather than building month strings itself.
+
+```js
+// Works whether or not the budget uses pay periods
+const months = await api.getBudgetMonths();
+const latest = months[months.length - 1];
+const budget = await api.getBudgetMonth(latest);
+
+// Breaks when the budget uses pay periods
+const budget = await api.getBudgetMonth('2026-01');
+```
+
+If a script has to work with real dates, read the identifiers from `getBudgetMonths()` and pick the one you need, instead of formatting a date into `YYYY-MM` yourself.

--- a/packages/eslint-plugin-actual/lib/index.js
+++ b/packages/eslint-plugin-actual/lib/index.js
@@ -13,6 +13,7 @@ module.exports = eslintCompatPlugin({
     'object-shorthand-properties': require('./rules/object-shorthand-properties'),
     'prefer-const': require('./rules/prefer-const'),
     'no-anchor-tag': require('./rules/no-anchor-tag'),
+    'no-month-date-concat': require('./rules/no-month-date-concat'),
     'no-enum': require('./rules/no-enum'),
     'no-react-default-import': require('./rules/no-react-default-import'),
     'prefer-subpath-imports': require('./rules/prefer-subpath-imports'),

--- a/packages/eslint-plugin-actual/lib/rules/__tests__/no-month-date-concat.test.js
+++ b/packages/eslint-plugin-actual/lib/rules/__tests__/no-month-date-concat.test.js
@@ -1,0 +1,70 @@
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+import { runClassic } from 'eslint-vitest-rule-tester';
+
+import plugin from '../../index';
+const rule = plugin.rules['no-month-date-concat'];
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+void runClassic(
+  'no-month-date-concat',
+  rule,
+  {
+    valid: [
+      // The sanctioned helpers
+      `const day = monthUtils.firstDayOfMonth(month);`,
+      `const range = monthUtils.budgetColumnDayRange(month);`,
+
+      // String concatenation that isn't a date segment
+      `const label = name + '-suffix';`,
+      `const id = base + '-1';`,
+      `const id = base + '-123';`,
+
+      // Template literals without a trailing date segment
+      `const label = \`\${month} overview\`;`,
+      `const key = \`\${sheetName}!\${cellName}\`;`,
+
+      // No expression involved — a plain literal is someone writing a date
+      'const day = `2026-01-01`;',
+    ],
+
+    invalid: [
+      {
+        code: `const day = month + '-01';`,
+        output: null,
+        errors: [{ messageId: 'noConcat' }],
+      },
+      {
+        code: `const day = year + '-01-01';`,
+        output: null,
+        errors: [{ messageId: 'noConcat' }],
+      },
+      {
+        code: `const parsed = d.parseISO(endMonth + '-01');`,
+        output: null,
+        errors: [{ messageId: 'noConcat' }],
+      },
+      {
+        code: `const day = \`\${template.month}-01\`;`,
+        output: null,
+        errors: [{ messageId: 'noConcat' }],
+      },
+      {
+        code: `const day = \`\${year}-12-31\`;`,
+        output: null,
+        errors: [{ messageId: 'noConcat' }],
+      },
+    ],
+  },
+  {
+    parserOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+    },
+  },
+);

--- a/packages/eslint-plugin-actual/lib/rules/no-month-date-concat.js
+++ b/packages/eslint-plugin-actual/lib/rules/no-month-date-concat.js
@@ -1,0 +1,63 @@
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+// Matches a date-segment suffix being glued onto an expression:
+// `month + '-01'`, `${month}-01`, `${year}-01-01`.
+const SEGMENT_SUFFIX = /^-\d{2}(-\d{2})?$/;
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Forbid building dates by concatenating segments onto month IDs; ' +
+        'a budget column can be a pay period, whose ID is not a parseable ' +
+        'calendar month',
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      noConcat:
+        "Don't build a date by appending '{{suffix}}' to a month value: a " +
+        'budget column ID can be a pay period (`2026-13`), which this turns ' +
+        'into a nonsense date that fails silently. Use the helpers in ' +
+        'loot-core shared/months instead — `firstDayOfMonth`/`lastDayOfMonth` ' +
+        'for a calendar month, `budgetColumnDayRange` for a budget column.',
+    },
+  },
+
+  createOnce(context) {
+    function report(node, suffix) {
+      context.report({
+        node,
+        messageId: 'noConcat',
+        data: { suffix },
+      });
+    }
+
+    return {
+      BinaryExpression(node) {
+        if (
+          node.operator === '+' &&
+          node.right.type === 'Literal' &&
+          typeof node.right.value === 'string' &&
+          SEGMENT_SUFFIX.test(node.right.value)
+        ) {
+          report(node, node.right.value);
+        }
+      },
+      TemplateLiteral(node) {
+        if (node.expressions.length === 0) {
+          return;
+        }
+        const lastQuasi = node.quasis[node.quasis.length - 1];
+        const value = lastQuasi.value.cooked;
+        if (typeof value === 'string' && SEGMENT_SUFFIX.test(value)) {
+          report(node, value);
+        }
+      },
+    };
+  },
+};

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -469,6 +469,11 @@ handlers['api/budget-set-amount'] = withMutation(async function ({
   amount,
 }) {
   checkFileOpen();
+  // The only budget write that used to skip this. Without it, a month that
+  // has no budget column — a calendar month while the file budgets by pay
+  // period, say — writes a row that nothing ever reads back, so the amount
+  // is silently discarded instead of reported.
+  await validateMonth(month);
   return handlers['budget/budget-amount']({
     month,
     category: categoryId,

--- a/packages/loot-core/src/server/budget/actions.ts
+++ b/packages/loot-core/src/server/budget/actions.ts
@@ -7,6 +7,7 @@ import { batchMessages } from '#server/sync';
 import { getCurrency } from '#shared/currencies';
 import { getLocale } from '#shared/locale';
 import * as monthUtils from '#shared/months';
+import { payPeriodsActive } from '#shared/pay-period-config';
 import { integerToCurrency, safeNumber } from '#shared/util';
 import type { IntegerAmount } from '#shared/util';
 import type { CategoryEntity } from '#types/models';
@@ -54,6 +55,12 @@ export function isTrackingBudget(): boolean {
   const val = budgetType ? budgetType.value : 'envelope';
   return val === 'tracking';
 }
+
+// The `month` integer column of the budget tables encodes calendar months
+// as MM 01-12 and pay periods as MM 13-99 (see shared/pay-periods.ts), so
+// `month % 100` tells the two ID spaces apart.
+const FIRST_PAY_PERIOD_NUMBER = 13;
+const LAST_PAY_PERIOD_NUMBER = 99;
 
 function dbMonth(month: string): number {
   return parseInt(month.replace('-', ''));
@@ -150,6 +157,25 @@ export function setBudget({
     category,
     amount,
   });
+}
+
+/**
+ * Whether the category has any non-zero budgeted amount, in any budget
+ * column of either mode.
+ *
+ * Calendar months and pay periods share the budget table, but only the
+ * active mode's columns have spreadsheet sheets — so anything that walks
+ * the created months (or their sheets) is blind to money budgeted in the
+ * other mode. This reads the table directly so that money still counts.
+ */
+export async function hasBudgetedAmount(categoryId: string): Promise<boolean> {
+  const table = getBudgetTable();
+  const row = await db.first<{ count: number }>(
+    `SELECT COUNT(*) AS count FROM ${table}
+      WHERE category = ? AND IFNULL(amount, 0) != 0`,
+    [categoryId],
+  );
+  return (row?.count ?? 0) > 0;
 }
 
 export function setGoal({ month, category, goal, long_goal }): Promise<void> {
@@ -464,9 +490,20 @@ async function getFirstActivityMonth({
 }): Promise<string | null> {
   const table = getBudgetTable();
   const endDbMonth = dbMonth(endMonth);
+
+  // Both modes store their budget columns in the same `month` integer
+  // column (202601 for January 2026, 202613 for its first pay period), and
+  // calendar columns always sort below pay period ones. An unrestricted
+  // MIN() therefore hands back a column from the *other* mode, which
+  // callers then compare against columns of the active mode. Restrict the
+  // query to the ID space of the active mode.
+  const [minMonthNumber, maxMonthNumber] = payPeriodsActive()
+    ? [FIRST_PAY_PERIOD_NUMBER, LAST_PAY_PERIOD_NUMBER]
+    : [1, 12];
   const firstBudget = await db.first<{ month: number | null }>(
-    `SELECT MIN(month) AS month FROM ${table} WHERE category = ? AND month <= ?`,
-    [categoryId, endDbMonth],
+    `SELECT MIN(month) AS month FROM ${table}
+      WHERE category = ? AND month <= ? AND month % 100 BETWEEN ? AND ?`,
+    [categoryId, endDbMonth, minMonthNumber, maxMonthNumber],
   );
 
   // Transactions are matched by date containment (through the end of

--- a/packages/loot-core/src/server/budget/app.ts
+++ b/packages/loot-core/src/server/budget/app.ts
@@ -501,11 +501,10 @@ async function isCategoryTransferRequired({
   }
 
   // If there are any non-zero budget values, also force the user to
-  // transfer the category.
-  return [...(sheet.get().meta().createdMonths as Set<string>)].some(month => {
-    const sheetName = monthUtils.sheetForMonth(month);
-    const value = sheet.get().getCellValue(sheetName, 'budget-' + id);
-
-    return value != null && value !== 0;
-  });
+  // transfer the category. This looks at the budget table rather than the
+  // created months' sheets: those only cover the active mode's columns, so
+  // money budgeted in the other mode's columns (calendar months while pay
+  // periods are on, or vice versa) would otherwise never prompt and become
+  // unreachable once the category is deleted.
+  return actions.hasBudgetedAmount(id);
 }

--- a/packages/loot-core/src/server/budget/base.ts
+++ b/packages/loot-core/src/server/budget/base.ts
@@ -307,6 +307,12 @@ export function triggerBudgetChanges(oldValues, newValues) {
 }
 
 export async function doTransfer(categoryIds, transferId) {
+  // Only the active mode's budget columns are transferred: `createdMonths`
+  // holds calendar months or pay periods, never both, and only those have
+  // sheets to recompute. Money budgeted in the other mode's columns still
+  // makes the transfer prompt appear (see `isCategoryTransferRequired`), so
+  // it is never silently dropped, but moving it is left to the mode it
+  // belongs to.
   const { createdMonths: months } = sheet.get().meta();
 
   [...months].forEach(month => {

--- a/packages/loot-core/src/server/budget/category-template-context.pay-periods.test.ts
+++ b/packages/loot-core/src/server/budget/category-template-context.pay-periods.test.ts
@@ -1,0 +1,349 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Currency } from '#shared/currencies';
+import {
+  resetPayPeriodConfigForTesting,
+  setPayPeriodConfig,
+} from '#shared/pay-period-config';
+import { generatePayPeriods } from '#shared/pay-periods';
+import type { PayPeriodConfig } from '#shared/pay-periods';
+import type { CategoryEntity } from '#types/models';
+import type { Template } from '#types/models/templates';
+
+import { getSheetValue } from './actions';
+import { CategoryTemplateContext } from './category-template-context';
+
+// Mirrors the mock in the calendar suite (category-template-context.test.ts).
+vi.mock('./actions', () => ({
+  getCategoryAverage: vi.fn(),
+  getSheetValue: vi.fn(),
+  getSheetBoolean: vi.fn(),
+  isTrackingBudget: vi.fn(),
+}));
+
+// Weekly periods anchored on 2024-01-01, so each period is a whole week and
+// January 2024 spans '2024-13' (Jan 1-7) through '2024-17' (Jan 29 - Feb 4).
+const weeklyConfig: PayPeriodConfig = {
+  payFrequency: 'weekly',
+  startDate: '2024-01-01',
+};
+
+const periods2024 = generatePayPeriods(2024, weeklyConfig);
+
+function periodContaining(day: string): string {
+  const period = periods2024.find(p => day >= p.startDate && day <= p.endDate);
+  if (!period) {
+    throw new Error(`No 2024 pay period contains ${day}`);
+  }
+  return period.monthId;
+}
+
+const currency: Currency = {
+  code: '',
+  symbol: '',
+  name: '',
+  decimalPlaces: 2,
+  numberFormat: 'comma-dot',
+  symbolFirst: false,
+};
+
+const category = { id: 'cat-1', name: 'Test Category' } as CategoryEntity;
+
+/** Exposes the protected constructor, as the calendar suite does. */
+class TestCategoryTemplateContext extends CategoryTemplateContext {
+  public constructor(
+    templates: Template[],
+    categoryEntity: CategoryEntity,
+    month: string,
+    fromLastMonth: number,
+    budgeted: number,
+  ) {
+    super(
+      templates,
+      categoryEntity,
+      month,
+      fromLastMonth,
+      budgeted,
+      'USD',
+      false,
+    );
+  }
+}
+
+/**
+ * The template runners are static and read only a few fields off the
+ * context, so a literal stands in for a fully initialized instance (which
+ * would need a live spreadsheet).
+ */
+function makeContext(
+  month: string,
+  extra: { fromLastMonth?: number; templates?: Template[] } = {},
+): CategoryTemplateContext {
+  return {
+    month,
+    currency,
+    category,
+    fromLastMonth: extra.fromLastMonth ?? 0,
+    templates: extra.templates ?? [],
+  } as unknown as CategoryTemplateContext;
+}
+
+describe('runPeriodic in pay period mode', () => {
+  afterEach(() => {
+    resetPayPeriodConfigForTesting();
+  });
+
+  const weeklyTemplate = {
+    type: 'periodic' as const,
+    amount: 25,
+    period: { period: 'week' as const, amount: 1 },
+    starting: '2024-01-03',
+    directive: 'template' as const,
+    priority: 1,
+  };
+
+  it('budgets one occurrence per weekly period, not five', () => {
+    // Calendar January contains five Wednesdays from the 3rd, so the
+    // calendar-month answer is 5 x $25. Each weekly period contains one.
+    resetPayPeriodConfigForTesting();
+    expect(
+      CategoryTemplateContext.runPeriodic(
+        weeklyTemplate,
+        makeContext('2024-01'),
+      ),
+    ).toBe(12500);
+
+    setPayPeriodConfig(weeklyConfig);
+    expect(
+      CategoryTemplateContext.runPeriodic(
+        weeklyTemplate,
+        makeContext('2024-13'),
+      ),
+    ).toBe(2500);
+    expect(
+      CategoryTemplateContext.runPeriodic(
+        weeklyTemplate,
+        makeContext('2024-14'),
+      ),
+    ).toBe(2500);
+  });
+
+  it('budgets nothing in a period the occurrence misses', () => {
+    setPayPeriodConfig(weeklyConfig);
+    const monthlyTemplate = {
+      ...weeklyTemplate,
+      amount: 100,
+      period: { period: 'month' as const, amount: 1 },
+      starting: '2024-01-15',
+    };
+
+    // Jan 15 falls in one period only; the periods before it get nothing.
+    expect(
+      CategoryTemplateContext.runPeriodic(
+        monthlyTemplate,
+        makeContext(periodContaining('2024-01-15')),
+      ),
+    ).toBe(10000);
+    expect(
+      CategoryTemplateContext.runPeriodic(
+        monthlyTemplate,
+        makeContext(periodContaining('2024-01-08')),
+      ),
+    ).toBe(0);
+  });
+
+  it('defaults the start to the period start, not the calendar month start', () => {
+    setPayPeriodConfig(weeklyConfig);
+    const noStartDate = {
+      ...weeklyTemplate,
+      amount: 10,
+      period: { period: 'day' as const, amount: 1 },
+      starting: '',
+    };
+
+    // A daily template with no start date runs from the first day of the
+    // budget column: seven days in a weekly period, not 31 in January.
+    expect(
+      CategoryTemplateContext.runPeriodic(noStartDate, makeContext('2024-13')),
+    ).toBe(7000);
+  });
+});
+
+describe('weekly `up to` limit in pay period mode', () => {
+  afterEach(() => {
+    resetPayPeriodConfigForTesting();
+  });
+
+  const weeklyLimit: Template = {
+    type: 'simple',
+    limit: { amount: 100, hold: false, period: 'weekly', start: '2024-01-01' },
+    directive: 'template',
+    priority: 1,
+  };
+
+  it('counts the weekly occurrences inside the period, not the year', async () => {
+    // The calendar answer for January is five Mondays x $100.
+    resetPayPeriodConfigForTesting();
+    const calendar = new TestCategoryTemplateContext(
+      [weeklyLimit],
+      category,
+      '2024-01',
+      0,
+      0,
+    );
+    expect(await calendar.runTemplatesForPriority(1, 100000, 100000)).toBe(
+      50000,
+    );
+
+    // A weekly pay period contains exactly one of them. Before the fix the
+    // limit resolved to 0, which reads as "already met" and budgets nothing.
+    setPayPeriodConfig(weeklyConfig);
+    const period = new TestCategoryTemplateContext(
+      [weeklyLimit],
+      category,
+      '2024-13',
+      0,
+      0,
+    );
+    expect(await period.runTemplatesForPriority(1, 100000, 100000)).toBe(10000);
+  });
+
+  it('scales the daily limit to the period length', async () => {
+    setPayPeriodConfig(weeklyConfig);
+    const dailyLimit: Template = {
+      type: 'simple',
+      limit: { amount: 10, hold: false, period: 'daily' },
+      directive: 'template',
+      priority: 1,
+    };
+    const period = new TestCategoryTemplateContext(
+      [dailyLimit],
+      category,
+      '2024-13',
+      0,
+      0,
+    );
+    // Seven days in a weekly period, not 31 in January.
+    expect(await period.runTemplatesForPriority(1, 100000, 100000)).toBe(7000);
+  });
+});
+
+describe('runSpend in pay period mode', () => {
+  beforeEach(() => {
+    vi.mocked(getSheetValue).mockResolvedValue(0);
+  });
+
+  afterEach(() => {
+    resetPayPeriodConfigForTesting();
+    vi.clearAllMocks();
+  });
+
+  const spendTemplate = {
+    type: 'spend' as const,
+    amount: 1200,
+    from: '2024-01',
+    month: '2024-03',
+    annual: false,
+    directive: 'template' as const,
+    priority: 1,
+  };
+
+  it('spreads the target over the remaining budget columns', async () => {
+    setPayPeriodConfig(weeklyConfig);
+
+    // '2024-13' is Jan 1-7. The goal is due by the end of March, which under
+    // a weekly cadence is many more columns away than the two calendar
+    // months a month-based count would report.
+    const perColumn = await CategoryTemplateContext.runSpend(
+      spendTemplate,
+      makeContext('2024-13'),
+    );
+
+    const calendarMonthsRemaining = 2;
+    const perCalendarMonth = Math.round(120000 / (calendarMonthsRemaining + 1));
+    expect(perColumn).toBeLessThan(perCalendarMonth);
+    expect(perColumn).toBeGreaterThan(0);
+
+    // Contributing `perColumn` in every column between now and the deadline
+    // reaches the target without overshooting by a whole cadence.
+    const columnsRemaining = Math.round(120000 / perColumn) - 1;
+    expect(columnsRemaining).toBeGreaterThan(calendarMonthsRemaining);
+  });
+
+  it('reads the budget columns already elapsed, not calendar sheets', async () => {
+    setPayPeriodConfig(weeklyConfig);
+
+    await CategoryTemplateContext.runSpend(
+      spendTemplate,
+      makeContext(periodContaining('2024-02-01')),
+    );
+
+    // Every sheet read has to name a pay period sheet. A calendar sheet name
+    // ('budget202401') is one that pay period mode never creates, and a
+    // missing sheet reads back as zero rather than raising — which is how
+    // the contributions already made used to get discarded.
+    const sheetNames = vi
+      .mocked(getSheetValue)
+      .mock.calls.map(([sheetName]) => sheetName);
+    expect(sheetNames.length).toBeGreaterThan(0);
+    for (const sheetName of sheetNames) {
+      const monthPart = sheetName.replace('budget', '').slice(4);
+      expect(Number(monthPart)).toBeGreaterThanOrEqual(13);
+    }
+  });
+
+  it('is unchanged in calendar mode', async () => {
+    resetPayPeriodConfigForTesting();
+
+    const perMonth = await CategoryTemplateContext.runSpend(
+      spendTemplate,
+      makeContext('2024-01'),
+    );
+
+    // Jan, Feb, Mar: three months to reach $1200.
+    expect(perMonth).toBe(40000);
+  });
+});
+
+describe('runBy in pay period mode', () => {
+  afterEach(() => {
+    resetPayPeriodConfigForTesting();
+  });
+
+  const byTemplate = {
+    type: 'by' as const,
+    amount: 600,
+    month: '2024-03',
+    annual: false,
+    directive: 'template' as const,
+    priority: 1,
+  };
+
+  it('divides the need by budget columns, not calendar months', () => {
+    resetPayPeriodConfigForTesting();
+    const { toBudget: calendarToBudget } = CategoryTemplateContext.runBy(
+      makeContext('2024-01', { templates: [byTemplate] }),
+    );
+    // Jan, Feb, Mar.
+    expect(calendarToBudget).toBe(20000);
+
+    setPayPeriodConfig(weeklyConfig);
+    const { toBudget: periodToBudget } = CategoryTemplateContext.runBy(
+      makeContext('2024-13', { templates: [byTemplate] }),
+    );
+    expect(periodToBudget).toBeLessThan(calendarToBudget);
+    expect(periodToBudget).toBeGreaterThan(0);
+  });
+
+  it('measures an annual repeat in budget columns too', () => {
+    setPayPeriodConfig(weeklyConfig);
+    const annual = { ...byTemplate, annual: true, repeat: 1 };
+
+    // A target already in the past rolls forward by the repeat rather than
+    // reporting a negative span and funding nothing.
+    const { toBudget } = CategoryTemplateContext.runBy(
+      makeContext(periodContaining('2024-06-01'), { templates: [annual] }),
+    );
+    expect(toBudget).toBeGreaterThan(0);
+  });
+});

--- a/packages/loot-core/src/server/budget/category-template-context.pay-periods.test.ts
+++ b/packages/loot-core/src/server/budget/category-template-context.pay-periods.test.ts
@@ -167,6 +167,47 @@ describe('runPeriodic in pay period mode', () => {
       CategoryTemplateContext.runPeriodic(noStartDate, makeContext('2024-13')),
     ).toBe(7000);
   });
+
+  it('a monthly cadence fires once per monthly period, keeping the anchor day', () => {
+    // A monthly pay cycle anchored on the 15th: '2024-13' runs Jan 15 -
+    // Feb 14. Shifting the occurrence with a day-losing month step snaps
+    // Feb 15 to Feb 1 — still inside the column — and a "$100 every month"
+    // template budgeted $200.
+    setPayPeriodConfig({ payFrequency: 'monthly', startDate: '2024-01-15' });
+    const monthlyTemplate = {
+      ...weeklyTemplate,
+      amount: 100,
+      period: { period: 'month' as const, amount: 1 },
+      starting: '2024-01-15',
+    };
+
+    expect(
+      CategoryTemplateContext.runPeriodic(
+        monthlyTemplate,
+        makeContext('2024-13'),
+      ),
+    ).toBe(10000);
+  });
+
+  it('keeps a mid-month monthly occurrence out of the column holding the 1st', () => {
+    // Biweekly from Jan 1: '2024-15' is Jan 29 - Feb 11. The next
+    // occurrence after Jan 29 is Feb 29 — outside the column. Snapping it
+    // to Feb 1 pulled it back inside and doubled the amount.
+    setPayPeriodConfig({ payFrequency: 'biweekly', startDate: '2024-01-01' });
+    const monthlyTemplate = {
+      ...weeklyTemplate,
+      amount: 100,
+      period: { period: 'month' as const, amount: 1 },
+      starting: '2024-01-29',
+    };
+
+    expect(
+      CategoryTemplateContext.runPeriodic(
+        monthlyTemplate,
+        makeContext('2024-15'),
+      ),
+    ).toBe(10000);
+  });
 });
 
 describe('weekly `up to` limit in pay period mode', () => {
@@ -226,6 +267,41 @@ describe('weekly `up to` limit in pay period mode', () => {
     // Seven days in a weekly period, not 31 in January.
     expect(await period.runTemplatesForPriority(1, 100000, 100000)).toBe(7000);
   });
+
+  it('pro-rates a monthly limit to the column, keeping the monthly cap honest', async () => {
+    const monthlyLimit: Template = {
+      type: 'simple',
+      limit: { amount: 600, hold: false, period: 'monthly' },
+      directive: 'template',
+      priority: 1,
+    };
+
+    // Calendar mode: the full monthly cap, unchanged.
+    resetPayPeriodConfigForTesting();
+    const calendar = new TestCategoryTemplateContext(
+      [monthlyLimit],
+      category,
+      '2024-01',
+      0,
+      0,
+    );
+    expect(await calendar.runTemplatesForPriority(1, 100000, 100000)).toBe(
+      60000,
+    );
+
+    // A weekly column gets a week's share of the cap: $600 x 7 / 30.4375.
+    // Applying the full monthly amount to every column quietly permitted
+    // ~4.3x the stated monthly spend on this cadence.
+    setPayPeriodConfig(weeklyConfig);
+    const period = new TestCategoryTemplateContext(
+      [monthlyLimit],
+      category,
+      '2024-13',
+      0,
+      0,
+    );
+    expect(await period.runTemplatesForPriority(1, 100000, 100000)).toBe(13799);
+  });
 });
 
 describe('runSpend in pay period mode', () => {
@@ -259,15 +335,10 @@ describe('runSpend in pay period mode', () => {
       makeContext('2024-13'),
     );
 
-    const calendarMonthsRemaining = 2;
-    const perCalendarMonth = Math.round(120000 / (calendarMonthsRemaining + 1));
-    expect(perColumn).toBeLessThan(perCalendarMonth);
-    expect(perColumn).toBeGreaterThan(0);
-
-    // Contributing `perColumn` in every column between now and the deadline
-    // reaches the target without overshooting by a whole cadence.
-    const columnsRemaining = Math.round(120000 / perColumn) - 1;
-    expect(columnsRemaining).toBeGreaterThan(calendarMonthsRemaining);
+    // The deadline is the column containing Mar 31 ('2024-25'), 12 columns
+    // out, so 13 columns share the $1,200: $92.31 each. The calendar-month
+    // answer would be $1,200 / 3 = $400.
+    expect(perColumn).toBe(9231);
   });
 
   it('reads the budget columns already elapsed, not calendar sheets', async () => {
@@ -331,8 +402,9 @@ describe('runBy in pay period mode', () => {
     const { toBudget: periodToBudget } = CategoryTemplateContext.runBy(
       makeContext('2024-13', { templates: [byTemplate] }),
     );
-    expect(periodToBudget).toBeLessThan(calendarToBudget);
-    expect(periodToBudget).toBeGreaterThan(0);
+    // Deadline column '2024-25' (the week of Mar 25), 12 columns out:
+    // $600 / 13 = $46.15 per column.
+    expect(periodToBudget).toBe(4615);
   });
 
   it('measures an annual repeat in budget columns too', () => {
@@ -340,10 +412,27 @@ describe('runBy in pay period mode', () => {
     const annual = { ...byTemplate, annual: true, repeat: 1 };
 
     // A target already in the past rolls forward by the repeat rather than
-    // reporting a negative span and funding nothing.
+    // reporting a negative span and funding nothing: '2024-03' becomes
+    // '2025-03', 44 columns out from the week of Jun 1 → $600 / 45.
     const { toBudget } = CategoryTemplateContext.runBy(
       makeContext(periodContaining('2024-06-01'), { templates: [annual] }),
     );
-    expect(toBudget).toBeGreaterThan(0);
+    expect(toBudget).toBe(1333);
+  });
+
+  it('a past non-repeating goal yields a finite number, not Infinity', () => {
+    setPayPeriodConfig(weeklyConfig);
+
+    // '2024-01' resolves to deadline column '2024-17' (the week holding
+    // Jan 31); the current column is 17 columns later. A distance clamped
+    // to -1 made the divisor (shortNumMonths + 1) zero, and
+    // Math.round(x / 0) = Infinity flowed on into the budget cell. The true
+    // signed distance matches calendar-mode semantics: $600 / -16.
+    const pastTarget = { ...byTemplate, month: '2024-01' };
+    const { toBudget } = CategoryTemplateContext.runBy(
+      makeContext(periodContaining('2024-06-01'), { templates: [pastTarget] }),
+    );
+    expect(Number.isFinite(toBudget)).toBe(true);
+    expect(toBudget).toBe(-3750);
   });
 });

--- a/packages/loot-core/src/server/budget/category-template-context.ts
+++ b/packages/loot-core/src/server/budget/category-template-context.ts
@@ -34,11 +34,22 @@ export class CategoryTemplateContext {
   /*----------------------------------------------------------------------------
    * Note on pay periods: `month` may be a pay period ID ('YYYY-MM' with
    * MM >= 13). Navigation between budget columns (prevMonth/subMonths/
-   * sheetForMonth/etc.) is period-aware, but template *semantics* that
-   * reference calendar time — target months in `by`/`spend` templates,
-   * `differenceInCalendarMonths` spans, weekly/daily limit math — stay
-   * intentionally calendar-based: template definitions are written in
-   * calendar terms regardless of the budget column cadence.
+   * sheetForMonth/etc.) is period-aware.
+   *
+   * Template *definitions* stay calendar-based — a goal is written as "by
+   * August", "every 2 months", "$50 a week" whatever the column cadence is —
+   * but anything that measures one of those windows against the budget has
+   * to be converted to budget columns first, via
+   * `monthUtils.budgetColumnDayRange` (for day comparisons) or
+   * `monthUtils.budgetColumnDistance` / `budgetColumnForCalendarMonth` (for
+   * spans). Two failure modes to keep in mind:
+   *
+   * - Comparing a day against `month` directly is only valid for calendar
+   *   months. A period ID sorts after every day of its year
+   *   ('2026-16' > '2026-12-31'), so such a test is silently always-true or
+   *   always-false rather than wrong-by-a-bit.
+   * - Dividing an amount by a *calendar* span yields a per-column
+   *   contribution that is too large, because a month holds several columns.
    *----------------------------------------------------------------------------
    * Using This Class:
    * 1. instantiate via `await categoryTemplate.init(templates, categoryID, month)`;
@@ -608,14 +619,21 @@ export class CategoryTemplateContext {
         if (!limitDef.start) {
           throw new Error('Weekly limit requires a start date (YYYY-MM-DD)');
         }
-        const nextMonth = monthUtils.nextMonth(this.month);
+        // Count the weekly occurrences that land inside this budget
+        // column. Comparing the days against `this.month` directly only
+        // works when the column is a calendar month: a pay period ID like
+        // '2026-16' sorts after every day in 2026 ('2026-16' > '2026-12-31'),
+        // so `week >= this.month` was never true and the limit resolved to
+        // zero — which reads as "limit already met" and budgets nothing.
+        const { start: columnStart, end: columnEnd } =
+          monthUtils.budgetColumnDayRange(this.month);
         let week = limitDef.start;
         const baseLimit = amountToInteger(
           limitDef.amount,
           this.currency.decimalPlaces,
         );
-        while (week < nextMonth) {
-          if (week >= this.month) {
+        while (week <= columnEnd) {
+          if (week >= columnStart) {
             this.limitAmount += baseLimit;
           }
           week = monthUtils.addWeeks(week, 1);
@@ -716,10 +734,18 @@ export class CategoryTemplateContext {
     );
     const period = template.period.period;
     const numPeriods = template.period.amount;
+    // The day range of this budget column — the pay period's own days while
+    // pay periods are active. Every comparison below is day-against-day:
+    // comparing days against the column ID directly only holds for calendar
+    // months, because a period ID like '2026-16' sorts after every day of
+    // 2026 and the occurrence walk then ran off the end of the year and
+    // budgeted nothing at all.
+    const { start: columnStart, end: columnEnd } =
+      monthUtils.budgetColumnDayRange(templateContext.month);
     let date =
       template.starting && template.starting.length > 0
         ? template.starting
-        : monthUtils.firstDayOfMonth(templateContext.month);
+        : columnStart;
 
     let dateShiftFunction;
     switch (period) {
@@ -741,21 +767,25 @@ export class CategoryTemplateContext {
         throw new Error(`Unrecognized periodic period: ${String(period)}`);
     }
 
+    // `addMonths` yields a 'yyyy-MM' month for the month and year cadences,
+    // which would not compare correctly against the 'yyyy-MM-dd' bounds
+    // below ('2024-01' sorts before '2024-01-01'). Normalize every step to a
+    // day so the whole walk stays day-against-day.
+    const shiftDate = (from: string | Date, by: number) =>
+      monthUtils.dayFromDate(dateShiftFunction(from, by));
+
     //shift the starting date until its in our month or in the future
-    while (templateContext.month > date) {
-      date = dateShiftFunction(date, numPeriods);
+    while (date < columnStart) {
+      date = shiftDate(date, numPeriods);
     }
 
-    if (
-      monthUtils.differenceInCalendarMonths(templateContext.month, date) < 0
-    ) {
+    if (date > columnEnd) {
       return 0;
     } // nothing needed this month
 
-    const nextMonth = monthUtils.addMonths(templateContext.month, 1);
-    while (date < nextMonth) {
+    while (date <= columnEnd) {
       toBudget += amount;
-      date = dateShiftFunction(date, numPeriods);
+      date = shiftDate(date, numPeriods);
     }
 
     return toBudget;
@@ -765,6 +795,10 @@ export class CategoryTemplateContext {
     template: SpendTemplate,
     templateContext: CategoryTemplateContext,
   ): Promise<number> {
+    // `template.from` and `template.month` are calendar months: a `spend`
+    // goal is written as "save $X by August, starting in March" whatever the
+    // budget column cadence is. The `repeat` shift below therefore stays in
+    // calendar months, and the columns are derived from the result.
     let fromMonth = `${template.from}`;
     let toMonth = `${template.month}`;
     let alreadyBudgeted = templateContext.fromLastMonth;
@@ -774,24 +808,29 @@ export class CategoryTemplateContext {
     const repeat = template.annual
       ? (template.repeat || 1) * 12
       : template.repeat;
-    let m = monthUtils.differenceInCalendarMonths(
-      toMonth,
+    let m = monthUtils.budgetColumnDistance(
       templateContext.month,
+      monthUtils.budgetColumnForCalendarMonth(toMonth, 'end'),
     );
     if (repeat && m < 0) {
       while (m < 0) {
         toMonth = monthUtils.addMonths(toMonth, repeat);
         fromMonth = monthUtils.addMonths(fromMonth, repeat);
-        m = monthUtils.differenceInCalendarMonths(
-          toMonth,
+        m = monthUtils.budgetColumnDistance(
           templateContext.month,
+          monthUtils.budgetColumnForCalendarMonth(toMonth, 'end'),
         );
       }
     }
 
+    // Walk budget columns, not calendar months: in pay period mode
+    // `sheetForMonth('2026-03')` names a sheet that was never created, and a
+    // missing sheet reads back as zero rather than raising — so every
+    // contribution already made was silently discarded and the goal
+    // re-budgeted its full remaining amount in every period.
     for (
-      let m = fromMonth;
-      monthUtils.differenceInCalendarMonths(templateContext.month, m) > 0;
+      let m = monthUtils.budgetColumnForCalendarMonth(fromMonth, 'start');
+      m < templateContext.month;
       m = monthUtils.addMonths(m, 1)
     ) {
       const sheetName = monthUtils.sheetForMonth(m);
@@ -815,9 +854,12 @@ export class CategoryTemplateContext {
       }
     }
 
-    const numMonths = monthUtils.differenceInCalendarMonths(
-      toMonth,
+    // Spread what is left over the budget columns still to come, not the
+    // calendar months: with several columns per month, dividing by months
+    // funds the goal a full cadence early and starves everything else.
+    const numMonths = monthUtils.budgetColumnDistance(
       templateContext.month,
+      monthUtils.budgetColumnForCalendarMonth(toMonth, 'end'),
     );
     const target = amountToInteger(
       template.amount,
@@ -926,23 +968,43 @@ export class CategoryTemplateContext {
     //find shortest time period
     for (let i = 0; i < byTemplates.length; i++) {
       const template = byTemplates[i];
+      // `template.month` is a calendar month ("by August") and `repeat` is a
+      // count of calendar months, but the amounts below are divided by this
+      // span to get a per-*column* contribution. With several columns per
+      // month a calendar span funds the goal a whole cadence early, so both
+      // the span and the repeat are measured in budget columns instead. The
+      // target month keeps advancing in calendar months, which is how the
+      // template is written.
       let targetMonth = `${template.month}`;
-      const period = template.annual
+      const calendarPeriod = template.annual
         ? (template.repeat || 1) * 12
         : template.repeat != null
           ? template.repeat
           : null;
-      let numMonths = monthUtils.differenceInCalendarMonths(
-        targetMonth,
+      let numMonths = monthUtils.budgetColumnDistance(
         templateContext.month,
+        monthUtils.budgetColumnForCalendarMonth(targetMonth, 'end'),
       );
-      while (numMonths < 0 && period) {
-        targetMonth = monthUtils.addMonths(targetMonth, period);
-        numMonths = monthUtils.differenceInCalendarMonths(
-          targetMonth,
+      while (numMonths < 0 && calendarPeriod) {
+        targetMonth = monthUtils.addMonths(targetMonth, calendarPeriod);
+        numMonths = monthUtils.budgetColumnDistance(
           templateContext.month,
+          monthUtils.budgetColumnForCalendarMonth(targetMonth, 'end'),
         );
       }
+      // One repeat cycle, in budget columns: the columns between the
+      // previous occurrence of this goal and the current target. Equals
+      // `calendarPeriod` exactly when pay periods are off.
+      const period =
+        calendarPeriod == null
+          ? null
+          : monthUtils.budgetColumnDistance(
+              monthUtils.budgetColumnForCalendarMonth(
+                monthUtils.subMonths(targetMonth, calendarPeriod),
+                'end',
+              ),
+              monthUtils.budgetColumnForCalendarMonth(targetMonth, 'end'),
+            );
       savedInfo.push({ numMonths, period });
       if (
         workingShortNumMonths === undefined ||

--- a/packages/loot-core/src/server/budget/category-template-context.ts
+++ b/packages/loot-core/src/server/budget/category-template-context.ts
@@ -3,6 +3,7 @@ import * as db from '#server/db';
 import { getCurrency } from '#shared/currencies';
 import type { Currency } from '#shared/currencies';
 import * as monthUtils from '#shared/months';
+import { isPayPeriod } from '#shared/pay-periods';
 import { q } from '#shared/query';
 import { amountToInteger, integerToAmount } from '#shared/util';
 import type { CategoryEntity } from '#types/models';
@@ -608,10 +609,10 @@ export class CategoryTemplateContext {
       }
 
       if (limitDef.period === 'daily') {
-        const numDays = monthUtils.differenceInCalendarDays(
-          monthUtils.addMonths(this.month, 1),
-          this.month,
-        );
+        const { start: columnStart, end: columnEnd } =
+          monthUtils.budgetColumnDayRange(this.month);
+        const numDays =
+          monthUtils.differenceInCalendarDays(columnEnd, columnStart) + 1;
         this.limitAmount +=
           amountToInteger(limitDef.amount, this.currency.decimalPlaces) *
           numDays;
@@ -639,10 +640,28 @@ export class CategoryTemplateContext {
           week = monthUtils.addWeeks(week, 1);
         }
       } else if (limitDef.period === 'monthly') {
-        this.limitAmount = amountToInteger(
+        const monthlyAmount = amountToInteger(
           limitDef.amount,
           this.currency.decimalPlaces,
         );
+        if (isPayPeriod(this.month)) {
+          // A monthly limit is a cap on a month's spending, so a column
+          // that covers only part of a month gets only that share — a
+          // biweekly column capped at the full monthly amount would quietly
+          // permit ~2.2x the stated monthly spend. (Contrast a fixed
+          // template amount, which is deliberately per-column: an
+          // allocation per paycheck, not a monthly total.)
+          const { start: columnStart, end: columnEnd } =
+            monthUtils.budgetColumnDayRange(this.month);
+          const numDays =
+            monthUtils.differenceInCalendarDays(columnEnd, columnStart) + 1;
+          const AVERAGE_DAYS_PER_MONTH = 365.25 / 12;
+          this.limitAmount = Math.round(
+            (monthlyAmount * numDays) / AVERAGE_DAYS_PER_MONTH,
+          );
+        } else {
+          this.limitAmount = monthlyAmount;
+        }
       } else {
         throw new Error('Invalid limit period. Check template syntax');
       }
@@ -747,7 +766,12 @@ export class CategoryTemplateContext {
         ? template.starting
         : columnStart;
 
-    let dateShiftFunction;
+    // Every shift must return a full 'yyyy-MM-dd' day that preserves the
+    // anchor day-of-month: the walk below is day-against-day, and a column
+    // can start mid-month, so an occurrence snapped to the 1st can land in
+    // the wrong column — or fire twice in one column (the anchor day and
+    // the following 1st both inside it).
+    let dateShiftFunction: (date: string, by: number) => string;
     switch (period) {
       case 'day':
         dateShiftFunction = monthUtils.addDays;
@@ -756,27 +780,19 @@ export class CategoryTemplateContext {
         dateShiftFunction = monthUtils.addWeeks;
         break;
       case 'month':
-        dateShiftFunction = monthUtils.addMonths;
+        dateShiftFunction = monthUtils.addMonthsToDay;
         break;
       case 'year':
-        // the addYears function doesn't return the month number, so use addMonths
-        dateShiftFunction = (date: string | Date, numPeriods: number) =>
-          monthUtils.addMonths(date, numPeriods * 12);
+        dateShiftFunction = (date: string, numPeriods: number) =>
+          monthUtils.addMonthsToDay(date, numPeriods * 12);
         break;
       default:
         throw new Error(`Unrecognized periodic period: ${String(period)}`);
     }
 
-    // `addMonths` yields a 'yyyy-MM' month for the month and year cadences,
-    // which would not compare correctly against the 'yyyy-MM-dd' bounds
-    // below ('2024-01' sorts before '2024-01-01'). Normalize every step to a
-    // day so the whole walk stays day-against-day.
-    const shiftDate = (from: string | Date, by: number) =>
-      monthUtils.dayFromDate(dateShiftFunction(from, by));
-
     //shift the starting date until its in our month or in the future
     while (date < columnStart) {
-      date = shiftDate(date, numPeriods);
+      date = dateShiftFunction(date, numPeriods);
     }
 
     if (date > columnEnd) {
@@ -785,7 +801,7 @@ export class CategoryTemplateContext {
 
     while (date <= columnEnd) {
       toBudget += amount;
-      date = shiftDate(date, numPeriods);
+      date = dateShiftFunction(date, numPeriods);
     }
 
     return toBudget;

--- a/packages/loot-core/src/server/budget/goal-template.pay-periods.test.ts
+++ b/packages/loot-core/src/server/budget/goal-template.pay-periods.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import * as db from '#server/db';
+import * as sheet from '#server/sheet';
+import * as monthUtils from '#shared/months';
+import {
+  resetPayPeriodConfigForTesting,
+  setPayPeriodConfig,
+} from '#shared/pay-period-config';
+import { generatePayPeriods } from '#shared/pay-periods';
+import type { PayPeriodConfig } from '#shared/pay-periods';
+
+import { getSheetValue, setBudget } from './actions';
+import { createBudget } from './base';
+import { applySingleCategoryTemplate } from './goal-template';
+
+/**
+ * Integration coverage for the goal template engine under pay periods,
+ * against a REAL database and spreadsheet.
+ *
+ * The unit tests in category-template-context.pay-periods.test.ts mock
+ * `getSheetValue` to return 0, which cannot tell the fixed code from the bug
+ * it fixed: reading a calendar sheet that pay period mode never creates also
+ * yields 0, silently. These tests read the real `budget-<id>` cell instead,
+ * so the assertion is on the money rather than on which sheet names a mock
+ * was handed.
+ */
+
+// The test clock is pinned to 2017-01-01 (see mocks/setup.ts). With this
+// cadence the 2017 periods start Jan 6, Jan 20, Feb 3, … and "now" falls in
+// the last period of 2016 (Dec 23 - Jan 5).
+const biweeklyConfig: PayPeriodConfig = {
+  payFrequency: 'biweekly',
+  startDate: '2017-01-06',
+};
+
+const periods2016 = generatePayPeriods(2016, biweeklyConfig);
+const LAST_PERIOD_2016 = periods2016[periods2016.length - 1].monthId;
+const FIRST_PERIOD_2017 = '2017-13'; // Jan 6 - Jan 19
+const SECOND_PERIOD_2017 = '2017-14'; // Jan 20 - Feb 2
+
+async function setupCategories() {
+  await db.insertCategoryGroup({ id: 'group1', name: 'Expenses' });
+  await db.insertCategoryGroup({ id: 'group2', name: 'Income', is_income: 1 });
+  const catId = await db.insertCategory({ name: 'Food', cat_group: 'group1' });
+  return { catId };
+}
+
+beforeEach(async () => {
+  await global.emptyDatabase()();
+  setPayPeriodConfig(biweeklyConfig);
+});
+
+afterEach(() => {
+  resetPayPeriodConfigForTesting();
+});
+
+describe('goal templates against real pay period sheets', () => {
+  it('spend counts what earlier period columns already contributed', async () => {
+    await sheet.loadSpreadsheet(db);
+    const { catId } = await setupCategories();
+
+    await createBudget([
+      LAST_PERIOD_2016,
+      FIRST_PERIOD_2017,
+      SECOND_PERIOD_2017,
+    ]);
+    await sheet.waitOnSpreadsheet();
+
+    // $300 already set aside towards the goal, in a period column that has
+    // already elapsed. This is the value the buggy version threw away: it
+    // walked calendar months and read 'budget201701', a sheet pay period
+    // mode never creates, which reads back as 0 instead of raising.
+    await setBudget({
+      category: catId,
+      month: FIRST_PERIOD_2017,
+      amount: 30000,
+    });
+    await sheet.waitOnSpreadsheet();
+
+    // "$1200 by March, saving from January."
+    await db.update('notes', {
+      id: catId,
+      note: '#template 1200 by 2017-03 spend from 2017-01',
+    });
+
+    await applySingleCategoryTemplate({
+      month: SECOND_PERIOD_2017,
+      category: catId,
+    });
+    await sheet.waitOnSpreadsheet();
+
+    // The deadline resolves to the period containing Mar 31 2017, five
+    // columns after this one, so six columns share the remaining $900.
+    const target = 120000;
+    const alreadyBudgeted = 30000;
+    const columnsRemaining = monthUtils.budgetColumnDistance(
+      SECOND_PERIOD_2017,
+      monthUtils.budgetColumnForCalendarMonth('2017-03', 'end'),
+    );
+    expect(columnsRemaining).toBe(5);
+
+    const expected = Math.round(
+      (target - alreadyBudgeted) / (columnsRemaining + 1),
+    );
+    expect(expected).toBe(15000);
+
+    expect(
+      await getSheetValue(
+        monthUtils.sheetForMonth(SECOND_PERIOD_2017),
+        `budget-${catId}`,
+      ),
+    ).toBe(expected);
+  });
+
+  it('by divides the goal across budget columns, not calendar months', async () => {
+    await sheet.loadSpreadsheet(db);
+    const { catId } = await setupCategories();
+
+    await createBudget([FIRST_PERIOD_2017, SECOND_PERIOD_2017]);
+    await sheet.waitOnSpreadsheet();
+
+    // "$600 by March."
+    await db.update('notes', {
+      id: catId,
+      note: '#template 600 by 2017-03',
+    });
+
+    await applySingleCategoryTemplate({
+      month: SECOND_PERIOD_2017,
+      category: catId,
+    });
+    await sheet.waitOnSpreadsheet();
+
+    const budgeted = await getSheetValue(
+      monthUtils.sheetForMonth(SECOND_PERIOD_2017),
+      `budget-${catId}`,
+    );
+
+    // Six periods reach the deadline, so $100 each. Counting the two
+    // calendar months instead would put aside $200 a period and fund the
+    // goal a full cadence early, at the expense of every other category.
+    expect(budgeted).toBe(10000);
+
+    const calendarMonthsRemaining = monthUtils.differenceInCalendarMonths(
+      '2017-03',
+      SECOND_PERIOD_2017,
+    );
+    expect(budgeted).toBeLessThan(
+      Math.round(60000 / (calendarMonthsRemaining + 1)),
+    );
+  });
+});

--- a/packages/loot-core/src/server/budget/pay-period-config.test.ts
+++ b/packages/loot-core/src/server/budget/pay-period-config.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as connection from '#platform/server/connection';
+import * as db from '#server/db';
+import * as sheet from '#server/sheet';
+import {
+  getPayPeriodConfig,
+  resetPayPeriodConfigForTesting,
+  setPayPeriodConfig,
+} from '#shared/pay-period-config';
+
+import {
+  isPayPeriodPref,
+  loadPayPeriodConfig,
+  refreshPayPeriodConfig,
+} from './pay-period-config';
+
+/**
+ * `refreshPayPeriodConfig` is the single funnel for every way the pay
+ * period configuration can move — a local preference save, a change
+ * applied by sync from another device, and undo/redo. These tests run it
+ * against a real database and (where needed) a real spreadsheet, probing
+ * the rebuild through its observable effects rather than mocks.
+ */
+
+function seedPrefs(prefs: Record<string, string>) {
+  for (const [id, value] of Object.entries(prefs)) {
+    db.runQuery(
+      'INSERT OR REPLACE INTO preferences (id, value) VALUES (?, ?)',
+      [id, value],
+    );
+  }
+}
+
+async function setupCategories() {
+  await db.insertCategoryGroup({ id: 'group1', name: 'Expenses' });
+  await db.insertCategoryGroup({ id: 'group2', name: 'Income', is_income: 1 });
+  await db.insertCategory({ name: 'Food', cat_group: 'group1' });
+}
+
+const validPrefs = {
+  'flags.payPeriodsEnabled': 'true',
+  showPayPeriods: 'true',
+  payPeriodFrequency: 'biweekly',
+  payPeriodStartDate: '2017-01-06',
+};
+
+// The platform connection is already replaced with a manual mock by
+// mocks/setup.ts; spy on that shared instance — a second, file-level mock
+// would create a different module instance from the one the code under
+// test imports.
+let sendSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(async () => {
+  await global.emptyDatabase()();
+  resetPayPeriodConfigForTesting();
+  sendSpy = vi.spyOn(connection, 'send');
+});
+
+afterEach(() => {
+  sendSpy.mockRestore();
+});
+
+afterEach(() => {
+  resetPayPeriodConfigForTesting();
+});
+
+describe('loadPayPeriodConfig', () => {
+  it('requires both the feature flag and the display pref', () => {
+    seedPrefs({ ...validPrefs, 'flags.payPeriodsEnabled': 'false' });
+    expect(loadPayPeriodConfig()).toBeNull();
+
+    seedPrefs({ ...validPrefs, 'flags.payPeriodsEnabled': 'true' });
+    seedPrefs({ showPayPeriods: 'false' });
+    expect(loadPayPeriodConfig()).toBeNull();
+
+    seedPrefs(validPrefs);
+    expect(loadPayPeriodConfig()).toEqual({
+      payFrequency: 'biweekly',
+      startDate: '2017-01-06',
+    });
+  });
+
+  it('treats an invalid stored configuration as disabled, not an error', () => {
+    seedPrefs({ ...validPrefs, payPeriodStartDate: 'garbage' });
+    expect(loadPayPeriodConfig()).toBeNull();
+
+    seedPrefs({ ...validPrefs, payPeriodStartDate: '2017-02-30' });
+    expect(loadPayPeriodConfig()).toBeNull();
+  });
+});
+
+describe('isPayPeriodPref', () => {
+  it('matches exactly the prefs that feed the configuration', () => {
+    expect(isPayPeriodPref('flags.payPeriodsEnabled')).toBe(true);
+    expect(isPayPeriodPref('showPayPeriods')).toBe(true);
+    expect(isPayPeriodPref('payPeriodFrequency')).toBe(true);
+    expect(isPayPeriodPref('payPeriodStartDate')).toBe(true);
+    expect(isPayPeriodPref('budgetType')).toBe(false);
+  });
+});
+
+describe('refreshPayPeriodConfig', () => {
+  it('does nothing when the stored configuration matches the registry', async () => {
+    seedPrefs(validPrefs);
+    setPayPeriodConfig({ payFrequency: 'biweekly', startDate: '2017-01-06' });
+
+    await refreshPayPeriodConfig();
+
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+
+  it('rebuilds the budget before announcing the change to clients', async () => {
+    // Clients react to the announcement by re-binding the budget table, so
+    // the period sheets must exist by the time it fires. The rebuild's
+    // observable effect is `createdMonths` filling with period IDs; capture
+    // its size at announce time.
+    await sheet.loadSpreadsheet(db);
+    await setupCategories();
+    seedPrefs(validPrefs);
+
+    let monthsCreatedWhenAnnounced = -1;
+    sendSpy.mockImplementation((type: string) => {
+      if (type === 'pay-period-config-changed') {
+        monthsCreatedWhenAnnounced =
+          sheet.get().meta().createdMonths?.size ?? 0;
+      }
+    });
+
+    await refreshPayPeriodConfig();
+
+    expect(getPayPeriodConfig()).toEqual({
+      payFrequency: 'biweekly',
+      startDate: '2017-01-06',
+    });
+    expect(sendSpy).toHaveBeenCalledWith('pay-period-config-changed');
+    expect(monthsCreatedWhenAnnounced).toBeGreaterThan(0);
+    const createdMonths = [...sheet.get().meta().createdMonths] as string[];
+    expect(createdMonths.every(month => Number(month.slice(5)) >= 13)).toBe(
+      true,
+    );
+  });
+
+  it('deactivates and rebuilds calendar sheets when prefs turn pay periods off', async () => {
+    await sheet.loadSpreadsheet(db);
+    await setupCategories();
+    setPayPeriodConfig({ payFrequency: 'biweekly', startDate: '2017-01-06' });
+    seedPrefs({ ...validPrefs, showPayPeriods: 'false' });
+
+    await refreshPayPeriodConfig();
+
+    expect(getPayPeriodConfig()).toBeNull();
+    expect(sendSpy).toHaveBeenCalledWith('pay-period-config-changed');
+    const createdMonths = [...sheet.get().meta().createdMonths] as string[];
+    expect(createdMonths.length).toBeGreaterThan(0);
+    expect(createdMonths.every(month => Number(month.slice(5)) <= 12)).toBe(
+      true,
+    );
+  });
+
+  it('still updates the registry and announces when no budget file is open', async () => {
+    seedPrefs(validPrefs);
+
+    await refreshPayPeriodConfig();
+
+    expect(getPayPeriodConfig()).not.toBeNull();
+    expect(sendSpy).toHaveBeenCalledWith('pay-period-config-changed');
+  });
+});

--- a/packages/loot-core/src/server/budget/pay-period-config.ts
+++ b/packages/loot-core/src/server/budget/pay-period-config.ts
@@ -1,3 +1,4 @@
+import * as connection from '#platform/server/connection';
 import * as db from '#server/db';
 import * as sheet from '#server/sheet';
 import {
@@ -69,12 +70,26 @@ function configsEqual(
  * active configuration actually changed, the budget sheets are rebuilt so
  * the budget columns match the new mode (calendar months vs pay periods,
  * or a different period cadence).
+ *
+ * This is the single funnel for every way the configuration can move — a
+ * local save (server/preferences/app.ts), a change applied by sync from
+ * another device or tab, and undo/redo (server/sync applyMessages) — so
+ * it is also the one place that notifies the clients.
  */
 export async function refreshPayPeriodConfig(): Promise<void> {
   const previousConfig = getPayPeriodConfig();
   const activeConfig = setPayPeriodConfig(loadPayPeriodConfig());
 
-  if (!configsEqual(previousConfig, activeConfig) && sheet.get()) {
+  if (configsEqual(previousConfig, activeConfig)) {
+    return;
+  }
+
+  if (sheet.get()) {
     await rebuildBudgets();
   }
+
+  // Announced only after the rebuild: the client reacts by re-reading the
+  // synced prefs and re-binding the budget table, which must not happen
+  // while the sheets it reads are still being rebuilt.
+  connection.send('pay-period-config-changed');
 }

--- a/packages/loot-core/src/server/budget/pay-periods.test.ts
+++ b/packages/loot-core/src/server/budget/pay-periods.test.ts
@@ -10,7 +10,13 @@ import {
 import { generatePayPeriods, isPayPeriod } from '#shared/pay-periods';
 import type { PayPeriodConfig } from '#shared/pay-periods';
 
-import { copyPreviousMonth, getSheetValue, setBudget } from './actions';
+import {
+  copyPreviousMonth,
+  getCategoryAverage,
+  getSheetValue,
+  setBudget,
+} from './actions';
+import { app } from './app';
 import { createAllBudgets, createBudget, getBudgetRange } from './base';
 
 // In tests the current day is 2017-01-01 (see mocks/setup.ts). With this
@@ -25,6 +31,17 @@ const biweeklyConfig: PayPeriodConfig = {
 const periods2016 = generatePayPeriods(2016, biweeklyConfig);
 const lastPeriod2016 = periods2016[periods2016.length - 1];
 const periods2017 = generatePayPeriods(2017, biweeklyConfig);
+
+function periodById(monthId: string) {
+  const year = Number(monthId.slice(0, 4));
+  const period = generatePayPeriods(year, biweeklyConfig).find(
+    p => p.monthId === monthId,
+  );
+  if (!period) {
+    throw new Error(`No pay period '${monthId}' for this config`);
+  }
+  return period;
+}
 
 async function setupCategories() {
   await db.insertCategoryGroup({ id: 'group1', name: 'Expenses' });
@@ -225,5 +242,112 @@ describe('budget actions with pay periods', () => {
 
     const sheetP2 = monthUtils.sheetForMonth(periods2017[1].monthId);
     expect(await getSheetValue(sheetP2, `budget-${catId}`)).toBe(4200);
+  });
+});
+
+describe('getCategoryAverage with pay periods', () => {
+  it("averages period columns and ignores the other mode's budget rows", async () => {
+    await sheet.loadSpreadsheet(db);
+    const { catId } = await setupCategories();
+    await db.insertAccount({ id: 'account1', name: 'Account 1' });
+
+    // The current day (2017-01-01) falls in the last period of 2016, so
+    // averaging from that period looks back at the periods before it.
+    const current = lastPeriod2016.monthId;
+    const oneBack = monthUtils.subMonths(current, 1);
+    const twoBack = monthUtils.subMonths(current, 2);
+    const threeBack = monthUtils.subMonths(current, 3);
+
+    await db.insertTransaction({
+      date: periodById(oneBack).startDate,
+      amount: -3000,
+      account: 'account1',
+      category: catId,
+    });
+    await db.insertTransaction({
+      date: periodById(twoBack).startDate,
+      amount: -1000,
+      account: 'account1',
+      category: catId,
+    });
+
+    await createBudget([threeBack, twoBack, oneBack, current]);
+    await sheet.waitOnSpreadsheet();
+
+    // A calendar-month budget row left behind by a session with pay
+    // periods disabled. 201612 sorts below every period row of the same
+    // year, so an unrestricted MIN(month) reports it as the category's
+    // first activity month and the average then spans periods with no
+    // activity at all.
+    db.runQuery(
+      'INSERT INTO zero_budgets (id, month, category, amount) VALUES (?, ?, ?, ?)',
+      [`201612-${catId}`, 201612, catId, 50000],
+    );
+
+    // Activity starts two periods back, so only two columns are averaged
+    // no matter how far the window reaches.
+    expect(
+      await getCategoryAverage({
+        month: current,
+        maxMonths: 3,
+        categoryId: catId,
+      }),
+    ).toBe(-2000);
+    expect(
+      await getCategoryAverage({
+        month: current,
+        maxMonths: 12,
+        categoryId: catId,
+      }),
+    ).toBe(-2000);
+  });
+});
+
+describe('category transfer requirement with pay periods', () => {
+  const mustTransfer = app.handlers['must-category-transfer'];
+
+  it('is not required for a category with no budgeted money', async () => {
+    await sheet.loadSpreadsheet(db);
+    const { catId } = await setupCategories();
+
+    await createBudget([periods2017[0].monthId, periods2017[1].monthId]);
+    await sheet.waitOnSpreadsheet();
+
+    expect(await mustTransfer({ id: catId })).toBe(false);
+  });
+
+  it('is required for money budgeted in a period column', async () => {
+    await sheet.loadSpreadsheet(db);
+    const { catId } = await setupCategories();
+
+    await createBudget([periods2017[0].monthId, periods2017[1].monthId]);
+    await sheet.waitOnSpreadsheet();
+
+    await setBudget({
+      category: catId,
+      month: periods2017[0].monthId,
+      amount: 4200,
+    });
+    await sheet.waitOnSpreadsheet();
+
+    expect(await mustTransfer({ id: catId })).toBe(true);
+  });
+
+  it("is required for money budgeted only in the other mode's columns", async () => {
+    await sheet.loadSpreadsheet(db);
+    const { catId } = await setupCategories();
+
+    await createBudget([periods2017[0].monthId, periods2017[1].monthId]);
+    await sheet.waitOnSpreadsheet();
+
+    // Budgeted while pay periods were disabled: the calendar column has no
+    // sheet in this mode, so walking the created months' sheets never sees
+    // it and the money would vanish with the deleted category.
+    db.runQuery(
+      'INSERT INTO zero_budgets (id, month, category, amount) VALUES (?, ?, ?, ?)',
+      [`201701-${catId}`, 201701, catId, 12300],
+    );
+
+    expect(await mustTransfer({ id: catId })).toBe(true);
   });
 });

--- a/packages/loot-core/src/server/budget/schedule-template.pay-periods.test.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.pay-periods.test.ts
@@ -188,6 +188,35 @@ describe('runSchedule with pay periods', () => {
     expect(result.to_budget).toBe(Math.round(60000 / (columnsUntilDue + 1)));
   });
 
+  it('spreads a full sinking fund over the columns of the year, not 12 months', async () => {
+    // A yearly $1,200 schedule whose sinking fund is already full: the
+    // engine keeps contributing the steady-state base amount. That base is
+    // consumed once per budget column, so it has to be the target divided
+    // by the ~52 weekly columns of the recurrence interval — dividing by 12
+    // calendar months while adding it every column funded ~$5,200/yr.
+    mockSingleSchedule({
+      start: '2024-06-15',
+      amount: -120000,
+      frequency: 'yearly',
+    });
+
+    const result = await runSchedule(
+      templateLines,
+      '2024-13',
+      120000, // balance already covers the full target
+      0,
+      0,
+      0,
+      [],
+      defaultCategory,
+      defaultCurrency,
+    );
+    expect(result.errors).toHaveLength(0);
+    // Jan 1 + 12 months lands in '2024-65' (the Dec 30 - Jan 5 week): 52
+    // columns → $1,200 / 52 ≈ $23.08 per column.
+    expect(result.to_budget).toBe(2308);
+  });
+
   it('reports a schedule whose next occurrence is in an earlier period as past', async () => {
     vi.mocked(db.first).mockResolvedValue({ id: 1, completed: 0 });
     vi.mocked(getRuleForSchedule).mockResolvedValue(

--- a/packages/loot-core/src/server/budget/schedule-template.pay-periods.test.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.pay-periods.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as db from '#server/db';
+import { Rule } from '#server/rules';
+import { getRuleForSchedule } from '#server/schedules/app';
+import type { Currency } from '#shared/currencies';
+import * as monthUtils from '#shared/months';
+import {
+  resetPayPeriodConfigForTesting,
+  setPayPeriodConfig,
+} from '#shared/pay-period-config';
+import { generatePayPeriods } from '#shared/pay-periods';
+import type { PayPeriodConfig } from '#shared/pay-periods';
+import type { CategoryEntity } from '#types/models';
+
+import { isTrackingBudget } from './actions';
+import { runSchedule } from './schedule-template';
+
+vi.mock('#server/db');
+vi.mock('./actions');
+vi.mock('#server/schedules/app', async () => {
+  const actualModule = await vi.importActual('#server/schedules/app');
+  return {
+    ...actualModule,
+    getRuleForSchedule: vi.fn(),
+  };
+});
+
+// Weekly periods anchored on 2024-01-01, so January 2024 is covered by
+// four whole periods: Jan 1-7 ('2024-13'), Jan 8-14, Jan 15-21 and
+// Jan 22-28. A monthly bill lands in exactly one of them.
+const weeklyConfig: PayPeriodConfig = {
+  payFrequency: 'weekly',
+  startDate: '2024-01-01',
+};
+
+const periods2024 = generatePayPeriods(2024, weeklyConfig);
+
+function periodContaining(day: string): string {
+  const period = periods2024.find(p => day >= p.startDate && day <= p.endDate);
+  if (!period) {
+    throw new Error(`No 2024 pay period contains ${day}`);
+  }
+  return period.monthId;
+}
+
+const defaultCurrency: Currency = {
+  code: '',
+  symbol: '',
+  name: '',
+  decimalPlaces: 2,
+  numberFormat: 'comma-dot',
+  symbolFirst: false,
+};
+
+const defaultCategory = { id: '1', name: 'Test Category' } as CategoryEntity;
+
+const templateLines = [
+  {
+    type: 'schedule',
+    name: 'Test Schedule',
+    priority: 0,
+    directive: 'template',
+  } as const,
+];
+
+function mockSingleSchedule({
+  start,
+  amount,
+  frequency,
+  interval = 1,
+}: {
+  start: string;
+  amount: number;
+  frequency: 'monthly' | 'yearly' | 'weekly' | 'daily';
+  interval?: number;
+}) {
+  vi.mocked(db.first).mockResolvedValue({ id: 1, completed: 0 });
+  vi.mocked(getRuleForSchedule).mockResolvedValue(
+    new Rule({
+      id: 'r',
+      stage: 'pre',
+      conditionsOp: 'and',
+      conditions: [
+        {
+          op: 'is',
+          field: 'date',
+          value: {
+            start,
+            interval,
+            frequency,
+            patterns: [],
+            skipWeekend: false,
+            weekendSolveMode: 'before',
+            endMode: 'never',
+            endOccurrences: 1,
+            endDate: '2099-01-01',
+          },
+          type: 'date',
+        },
+        { op: 'is', field: 'amount', value: amount, type: 'number' },
+      ],
+      actions: [],
+    }),
+  );
+  vi.mocked(isTrackingBudget).mockReturnValue(false);
+}
+
+function budgetColumn(month: string) {
+  return runSchedule(
+    templateLines,
+    month,
+    0,
+    0,
+    0,
+    0,
+    [],
+    defaultCategory,
+    defaultCurrency,
+  );
+}
+
+describe('runSchedule with pay periods', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.getAccounts).mockResolvedValue([]);
+    setPayPeriodConfig(weeklyConfig);
+  });
+
+  afterEach(() => {
+    resetPayPeriodConfigForTesting();
+  });
+
+  it('funds a monthly schedule once across the pay periods of a calendar month', async () => {
+    mockSingleSchedule({
+      start: '2024-01-15',
+      amount: -10000,
+      frequency: 'monthly',
+    });
+
+    const januaryPeriods = ['2024-13', '2024-14', '2024-15', '2024-16'];
+    const budgeted: number[] = [];
+    for (const period of januaryPeriods) {
+      const result = await budgetColumn(period);
+      expect(result.errors).toHaveLength(0);
+      budgeted.push(result.to_budget);
+    }
+
+    // The period containing the 15th funds the whole bill; the other
+    // periods of the same calendar month fund nothing. Counting calendar
+    // months instead of budget columns made every period look like the due
+    // one and budget the full amount (~4x over-funding).
+    expect(periodContaining('2024-01-15')).toBe('2024-15');
+    expect(budgeted).toEqual([0, 0, 10000, 0]);
+    expect(budgeted.reduce((total, value) => total + value, 0)).toBe(10000);
+  });
+
+  it('funds a weekly schedule once per weekly pay period', async () => {
+    mockSingleSchedule({
+      start: '2024-01-01',
+      amount: -10000,
+      frequency: 'weekly',
+    });
+
+    // One occurrence per period — not every occurrence of the calendar
+    // month (or, as the mixed-unit comparison used to do, of the year).
+    for (const period of ['2024-13', '2024-14', '2024-15']) {
+      const result = await budgetColumn(period);
+      expect(result.errors).toHaveLength(0);
+      expect(result.to_budget).toBe(10000);
+    }
+  });
+
+  it('spreads a sinking schedule across the budget columns until it is due', async () => {
+    mockSingleSchedule({
+      start: '2024-12-15',
+      amount: -60000,
+      frequency: 'yearly',
+    });
+
+    const dueColumn = periodContaining('2024-12-15');
+    const columnsUntilDue =
+      monthUtils.rangeInclusive('2024-13', dueColumn).length - 1;
+    expect(columnsUntilDue).toBeGreaterThan(12);
+
+    const result = await budgetColumn('2024-13');
+    expect(result.errors).toHaveLength(0);
+    expect(result.to_budget).toBe(Math.round(60000 / (columnsUntilDue + 1)));
+  });
+
+  it('reports a schedule whose next occurrence is in an earlier period as past', async () => {
+    vi.mocked(db.first).mockResolvedValue({ id: 1, completed: 0 });
+    vi.mocked(getRuleForSchedule).mockResolvedValue(
+      new Rule({
+        id: 'r',
+        stage: 'pre',
+        conditionsOp: 'and',
+        conditions: [
+          { op: 'is', field: 'date', value: '2024-01-02', type: 'date' },
+          { op: 'is', field: 'amount', value: -10000, type: 'number' },
+        ],
+        actions: [],
+      }),
+    );
+    vi.mocked(isTrackingBudget).mockReturnValue(false);
+
+    // Jan 2 is in '2024-13', one period before the column being budgeted.
+    const result = await budgetColumn('2024-14');
+    expect(result.errors).toContainEqual(
+      expect.stringMatching(/is in the Past/),
+    );
+    expect(result.to_budget).toBe(0);
+  });
+});
+
+describe('runSchedule without pay periods', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.getAccounts).mockResolvedValue([]);
+    resetPayPeriodConfigForTesting();
+  });
+
+  it('keeps funding a monthly schedule in full every calendar month', async () => {
+    mockSingleSchedule({
+      start: '2024-01-15',
+      amount: -10000,
+      frequency: 'monthly',
+    });
+
+    for (const month of ['2024-01', '2024-02', '2024-03']) {
+      const result = await budgetColumn(month);
+      expect(result.errors).toHaveLength(0);
+      expect(result.to_budget).toBe(10000);
+    }
+  });
+
+  it('keeps spreading a yearly schedule across the calendar months until due', async () => {
+    mockSingleSchedule({
+      start: '2024-12-15',
+      amount: -60000,
+      frequency: 'yearly',
+    });
+
+    // 11 months until December, so the contribution is target / 12.
+    const result = await budgetColumn('2024-01-01');
+    expect(result.errors).toHaveLength(0);
+    expect(result.to_budget).toBe(5000);
+  });
+
+  it('keeps budgeting every daily occurrence of the calendar month', async () => {
+    mockSingleSchedule({
+      start: '2024-01-01',
+      amount: -100,
+      frequency: 'daily',
+    });
+
+    const result = await budgetColumn('2024-01-01');
+    expect(result.to_budget).toBe(3100); // 31 days × $1
+  });
+});

--- a/packages/loot-core/src/server/budget/schedule-template.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.ts
@@ -31,43 +31,9 @@ type ScheduleTemplateTarget = {
   repeat: boolean;
 };
 
-// Walking more columns than this means the schedule's next occurrence is
-// centuries away; bail out rather than spin. Weekly periods make ~53
-// columns a year, so this covers roughly a century of them.
-const MAX_BUDGET_COLUMN_DISTANCE = 6000;
-
-/**
- * Distance from one budget column to another, measured in budget columns.
- *
- * With pay periods several columns can share a calendar month, so a
- * calendar-month distance reports 0 for every column of that month and
- * each one would then fund the schedule in full. `monthUtils.nextMonth`
- * steps pay periods while they are active, so counting steps is correct in
- * both modes; calendar mode keeps using calendar-month arithmetic, which is
- * the same number.
- *
- * Negative distances (schedules in the past) are only ever tested for
- * their sign, so there is no need to walk backwards.
- */
-function budgetColumnDistance(from: string, to: string): number {
-  if (!payPeriodsActive()) {
-    return monthUtils.differenceInCalendarMonths(to, from);
-  }
-  if (to === from) {
-    return 0;
-  }
-  if (to < from) {
-    return -1;
-  }
-
-  let distance = 0;
-  let column = from;
-  while (column < to && distance < MAX_BUDGET_COLUMN_DISTANCE) {
-    column = monthUtils.nextMonth(column);
-    distance += 1;
-  }
-  return distance;
-}
+// `budgetColumnDistance` now lives in shared/months.ts, since the goal
+// template engine needs the same measurement (see category-template-context).
+const budgetColumnDistance = monthUtils.budgetColumnDistance;
 
 // Note on pay periods: `current_month` may be a pay period ID; `_parse`
 // resolves it to the period's start date and the addMonths/subMonths/

--- a/packages/loot-core/src/server/budget/schedule-template.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.ts
@@ -31,10 +31,6 @@ type ScheduleTemplateTarget = {
   repeat: boolean;
 };
 
-// `budgetColumnDistance` now lives in shared/months.ts, since the goal
-// template engine needs the same measurement (see category-template-context).
-const budgetColumnDistance = monthUtils.budgetColumnDistance;
-
 // Note on pay periods: `current_month` may be a pay period ID; `_parse`
 // resolves it to the period's start date and the addMonths/subMonths/
 // sheetForMonth navigation below is period-aware. Distances to a
@@ -160,7 +156,7 @@ async function createScheduleList(
     const num_months =
       due_column == null
         ? -1
-        : budgetColumnDistance(current_column, due_column);
+        : monthUtils.budgetColumnDistance(current_column, due_column);
     const displayName = scheduleName ?? template.name ?? '';
     if (num_months < 0) {
       //non-repeating schedules could be negative
@@ -283,14 +279,52 @@ function getSinkingContributionBreakdown(
   return { total, perSchedule };
 }
 
-function getMonthlyBaseContribution(schedule: ScheduleTemplateTarget) {
+/**
+ * The number of budget columns that cover the next `months` calendar
+ * months, anchored at the current column. Equals `months` in calendar
+ * mode; with pay periods a month holds several columns, so a per-month
+ * contribution consumed once per column has to be divided by this instead.
+ */
+function columnsInCalendarMonths(currentColumn: string, months: number) {
+  if (!payPeriodsActive()) {
+    return months;
+  }
+  const { start } = monthUtils.budgetColumnDayRange(currentColumn);
+  const intervalEndColumn = monthUtils.budgetMonthFromDate(
+    monthUtils.addMonthsToDay(start, months),
+  );
+  return Math.max(
+    1,
+    monthUtils.budgetColumnDistance(currentColumn, intervalEndColumn),
+  );
+}
+
+function getBaseContributionPerColumn(
+  schedule: ScheduleTemplateTarget,
+  currentColumn: string,
+) {
   let prevDate;
   let intervalMonths;
   switch (schedule.target_frequency) {
+    // For yearly/monthly (and non-recurring) schedules `target` is the full
+    // occurrence amount, so the recurrence interval has to be converted to
+    // budget columns: this contribution is consumed once per column, and
+    // dividing a yearly amount by 12 while adding it ~26 times a year would
+    // over-fund by the cadence factor.
     case 'yearly':
-      return schedule.target / schedule.target_interval / 12;
+      return (
+        schedule.target /
+        columnsInCalendarMonths(currentColumn, schedule.target_interval * 12)
+      );
     case 'monthly':
-      return schedule.target / schedule.target_interval;
+      return (
+        schedule.target /
+        columnsInCalendarMonths(currentColumn, schedule.target_interval)
+      );
+    // For weekly/daily schedules `target` is already column-granular — it
+    // was summed from the occurrences up to the end of the due column — so
+    // the calendar-month divisor stays as-is; converting it too would
+    // scale the contribution down twice.
     case 'weekly':
       prevDate = monthUtils.subWeeks(
         schedule.next_date_string,
@@ -315,13 +349,21 @@ function getMonthlyBaseContribution(schedule: ScheduleTemplateTarget) {
       return schedule.target / intervalMonths;
     default:
       // default to same math as monthly for now for non-reoccuring
-      return schedule.target / schedule.target_interval;
+      return (
+        schedule.target /
+        columnsInCalendarMonths(currentColumn, schedule.target_interval)
+      );
   }
 }
 
-function getSinkingBaseContributionTotal(t: ScheduleTemplateTarget[]) {
+function getSinkingBaseContributionTotal(
+  t: ScheduleTemplateTarget[],
+  currentColumn: string,
+) {
   let total = 0;
-  for (const schedule of t) total += getMonthlyBaseContribution(schedule);
+  for (const schedule of t) {
+    total += getBaseContributionPerColumn(schedule, currentColumn);
+  }
   return total;
 }
 
@@ -388,8 +430,10 @@ export async function runSchedule(
   const numSubMonthly = t.t.filter(isSubMonthly).length;
   const totalPayMonthOf = getPayMonthOfTotal(t_payMonthOf);
   const totalSinking = getSinkingTotal(t_sinking);
-  const totalSinkingBaseContribution =
-    getSinkingBaseContributionTotal(t_sinking);
+  const totalSinkingBaseContribution = getSinkingBaseContributionTotal(
+    t_sinking,
+    current_month,
+  );
   const lastMonthGoal = await getSheetValue(
     monthUtils.sheetForMonth(monthUtils.subMonths(current_month, 1)),
     `goal-${category.id}`,
@@ -424,7 +468,10 @@ export async function runSchedule(
       }
     }
     for (const c of t_sinking) {
-      addContribution(c.template, getMonthlyBaseContribution(c));
+      addContribution(
+        c.template,
+        getBaseContributionPerColumn(c, current_month),
+      );
     }
   } else {
     const { total: totalSinkingContribution, perSchedule: sinkingPerSchedule } =

--- a/packages/loot-core/src/server/budget/schedule-template.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.ts
@@ -6,6 +6,7 @@ import { getRuleForSchedule } from '#server/schedules/app';
 import { prefetchBalanceOfForTransaction } from '#server/transactions/transaction-rules';
 import type { Currency } from '#shared/currencies';
 import * as monthUtils from '#shared/months';
+import { payPeriodsActive } from '#shared/pay-period-config';
 import {
   extractScheduleConds,
   getDateWithSkippedWeekend,
@@ -30,12 +31,52 @@ type ScheduleTemplateTarget = {
   repeat: boolean;
 };
 
+// Walking more columns than this means the schedule's next occurrence is
+// centuries away; bail out rather than spin. Weekly periods make ~53
+// columns a year, so this covers roughly a century of them.
+const MAX_BUDGET_COLUMN_DISTANCE = 6000;
+
+/**
+ * Distance from one budget column to another, measured in budget columns.
+ *
+ * With pay periods several columns can share a calendar month, so a
+ * calendar-month distance reports 0 for every column of that month and
+ * each one would then fund the schedule in full. `monthUtils.nextMonth`
+ * steps pay periods while they are active, so counting steps is correct in
+ * both modes; calendar mode keeps using calendar-month arithmetic, which is
+ * the same number.
+ *
+ * Negative distances (schedules in the past) are only ever tested for
+ * their sign, so there is no need to walk backwards.
+ */
+function budgetColumnDistance(from: string, to: string): number {
+  if (!payPeriodsActive()) {
+    return monthUtils.differenceInCalendarMonths(to, from);
+  }
+  if (to === from) {
+    return 0;
+  }
+  if (to < from) {
+    return -1;
+  }
+
+  let distance = 0;
+  let column = from;
+  while (column < to && distance < MAX_BUDGET_COLUMN_DISTANCE) {
+    column = monthUtils.nextMonth(column);
+    distance += 1;
+  }
+  return distance;
+}
+
 // Note on pay periods: `current_month` may be a pay period ID; `_parse`
 // resolves it to the period's start date and the addMonths/subMonths/
-// sheetForMonth navigation below is period-aware. The schedule math itself
-// (calendar-month distances to the next occurrence, monthly contribution
-// targets) stays intentionally calendar-based — schedules are defined in
-// calendar time regardless of the budget column cadence.
+// sheetForMonth navigation below is period-aware. Distances to a
+// schedule's next occurrence are counted in budget columns (see
+// `budgetColumnDistance`), which is what the spreading and "pay month of"
+// logic downstream divides by. The schedule cadence itself stays
+// calendar-based — schedules are defined in calendar time regardless of
+// the budget column cadence.
 async function createScheduleList(
   templates: ScheduleTemplate[],
   current_month: string,
@@ -144,10 +185,16 @@ async function createScheduleList(
     const isRepeating =
       Object(dateConditions.value) === dateConditions.value &&
       'frequency' in dateConditions.value;
-    const num_months = monthUtils.differenceInCalendarMonths(
-      next_date_string,
-      current_month,
-    );
+    // The budget columns this schedule is scheduled against: the column
+    // being budgeted, and the one the next occurrence falls in.
+    const current_column = monthUtils.budgetMonthFromDate(current_month);
+    const due_column = next_date_string
+      ? monthUtils.budgetMonthFromDate(next_date_string)
+      : null;
+    const num_months =
+      due_column == null
+        ? -1
+        : budgetColumnDistance(current_column, due_column);
     const displayName = scheduleName ?? template.name ?? '';
     if (num_months < 0) {
       //non-repeating schedules could be negative
@@ -169,9 +216,12 @@ async function createScheduleList(
       if (!completed) {
         if (isRepeating) {
           let monthlyTarget = 0;
-          const nextMonth = monthUtils.addMonths(
-            current_month,
-            t[t.length - 1].num_months + 1,
+          // Exclusive end of the due column: the first day of the column
+          // after it. This has to be a day, not a column ID, because it is
+          // compared against occurrence dates — and a pay period ID like
+          // '2026-14' is not comparable to a 'yyyy-MM-dd' day.
+          const dueColumnEnd = monthUtils.dayFromDate(
+            monthUtils.nextMonth(due_column),
           );
           let nextBaseDate = getNextDate(
             dateConditions,
@@ -186,7 +236,7 @@ async function createScheduleList(
                 ),
               )
             : nextBaseDate;
-          while (nextDate < nextMonth) {
+          while (nextDate < dueColumnEnd) {
             monthlyTarget += -target;
             const currentDate = nextBaseDate;
             const oneDayLater = monthUtils.addDays(nextBaseDate, 1);
@@ -339,11 +389,25 @@ export async function runSchedule(
   );
   errors = errors.concat(t.errors);
 
+  // "Pay month of" schedules are funded in full in the budget column their
+  // occurrence lands in and are never pre-funded in earlier columns — only
+  // schedules whose `num_months` is 0 contribute (see getPayMonthOfTotal).
+  //
+  // A monthly schedule with a calendar column always lands in the column
+  // being budgeted, which is why `num_months === 0` holds there. Pay period
+  // columns can be shorter than a month, so the schedule lands in exactly
+  // one of the month's columns: that column funds it and the others fund
+  // nothing, instead of every column of the month funding it in full.
+  // Non-repeating schedules still require `num_months === 0`: they occur
+  // once, so they must be sunk into over the columns leading up to them.
+  const isMonthlyInPayPeriods = c =>
+    payPeriodsActive() && c.target_frequency === 'monthly';
+
   const isPayMonthOf = c =>
     c.full ||
     ((c.target_frequency === 'monthly' || !c.target_frequency) &&
       c.target_interval === 1 &&
-      c.num_months === 0) ||
+      (c.num_months === 0 || isMonthlyInPayPeriods(c))) ||
     (c.target_frequency === 'weekly' && c.target_interval <= 4) ||
     (c.target_frequency === 'daily' && c.target_interval <= 31) ||
     isTrackingBudget();

--- a/packages/loot-core/src/server/undo.test.ts
+++ b/packages/loot-core/src/server/undo.test.ts
@@ -1,0 +1,75 @@
+import * as db from '#server/db';
+import * as prefs from '#server/prefs';
+
+import { runMutator } from './mutators';
+import { setSyncingMode } from './sync';
+import { clearUndo, redo, undo, withUndo } from './undo';
+
+beforeEach(() => {
+  setSyncingMode('disabled');
+  clearUndo();
+  return global.emptyDatabase()();
+});
+
+async function savePreference(id: string, value: string | null) {
+  await runMutator(() =>
+    withUndo(async () => {
+      await db.update('preferences', { id, value });
+    }),
+  );
+}
+
+async function getPreferenceValue(id: string): Promise<string | null> {
+  const row = await db.first<Pick<db.DbPreference, 'value'>>(
+    'SELECT value FROM preferences WHERE id = ?',
+    [id],
+  );
+  return row?.value ?? null;
+}
+
+describe('undo of a synced preference', () => {
+  it('clears a preference that did not exist before instead of tombstoning it', async () => {
+    void prefs.loadPrefs();
+
+    // The `preferences` table is (id, value) with no tombstone column, so
+    // undoing the very first write of a key used to emit
+    // `SET tombstone = 1`, abort the transaction, and surface an
+    // `invalid-schema` sync error to the user. Toggling pay periods and
+    // pressing Ctrl+Z hit exactly this path.
+    await savePreference('showPayPeriods', 'true');
+    expect(await getPreferenceValue('showPayPeriods')).toBe('true');
+
+    await expect(runMutator(() => undo())).resolves.toBeUndefined();
+
+    // Cleared rather than reverted-to-missing; every reader treats an
+    // empty value as unset, so pay periods read as disabled again.
+    expect(await getPreferenceValue('showPayPeriods')).toBeNull();
+  });
+
+  it('redoes a preference that did not exist before', async () => {
+    void prefs.loadPrefs();
+
+    // The redo path resurrects rows by resetting their tombstone, which
+    // has the same "no tombstone column" problem as the undo path.
+    await savePreference('showPayPeriods', 'true');
+    await runMutator(() => undo());
+
+    await expect(runMutator(() => redo())).resolves.toBeUndefined();
+
+    expect(await getPreferenceValue('showPayPeriods')).toBe('true');
+  });
+
+  it('restores the previous value when the preference already existed', async () => {
+    void prefs.loadPrefs();
+
+    await savePreference('showPayPeriods', 'false');
+    clearUndo();
+
+    await savePreference('showPayPeriods', 'true');
+    expect(await getPreferenceValue('showPayPeriods')).toBe('true');
+
+    await runMutator(() => undo());
+
+    expect(await getPreferenceValue('showPayPeriods')).toBe('false');
+  });
+});

--- a/packages/loot-core/src/server/undo.ts
+++ b/packages/loot-core/src/server/undo.ts
@@ -193,7 +193,15 @@ function undoMessage(message, oldData) {
           return { ...message, value: 0 };
         }
         return null;
-      } else if (message.dataset === 'notes') {
+      } else if (
+        message.dataset === 'notes' ||
+        // `preferences` is (id, value) with no tombstone column, so the
+        // fallback below would emit `SET tombstone = 1` and abort the
+        // whole transaction with `invalid-schema`. Undoing a preference
+        // that didn't exist before means clearing its value, which every
+        // reader already treats as unset.
+        message.dataset === 'preferences'
+      ) {
         return { ...message, value: null };
       }
 
@@ -252,6 +260,9 @@ function redoResurrections(messages, oldData): Message[] {
         'notes',
         'category_mapping',
         'payee_mapping',
+        // Like the tables above, `preferences` has no tombstone column —
+        // resurrecting a row there would abort the transaction.
+        'preferences',
       ].includes(message.dataset)
     ) {
       resurrect.add(message.dataset + '.' + message.row);

--- a/packages/loot-core/src/shared/months.test.ts
+++ b/packages/loot-core/src/shared/months.test.ts
@@ -110,22 +110,36 @@ describe('pay period awareness', () => {
   it('budgetColumnDistance counts columns, and reports past targets as negative', () => {
     expect(monthUtils.budgetColumnDistance('2024-13', '2024-13')).toBe(0);
     expect(monthUtils.budgetColumnDistance('2024-13', '2024-16')).toBe(3);
-    expect(monthUtils.budgetColumnDistance('2024-16', '2024-13')).toBeLessThan(
-      0,
-    );
+    // A true signed distance, not a -1 sentinel: callers divide by these
+    // spans, so the magnitude matters as much as the sign.
+    expect(monthUtils.budgetColumnDistance('2024-16', '2024-13')).toBe(-3);
     // Across a year boundary: the last period of 2024 to the first of 2025.
     const lastOf2024 = monthUtils.getYearEnd('2024-13');
     expect(monthUtils.budgetColumnDistance(lastOf2024, '2025-13')).toBe(1);
   });
 
   it('budgetColumnForCalendarMonth maps a calendar target onto a column', () => {
-    // A goal due "by February" may use every column February contains, so
-    // the deadline is the column holding Feb 29.
+    // Hard-coded, not derived through budgetMonthFromDate — the helper is
+    // implemented in terms of it, so a derived expectation would cancel out
+    // any shared error. Biweekly from Jan 5: '2024-16' is Feb 16 - Feb 29
+    // and '2024-14' is Jan 19 - Feb 1.
     expect(monthUtils.budgetColumnForCalendarMonth('2024-02', 'end')).toBe(
-      monthUtils.budgetMonthFromDate('2024-02-29'),
+      '2024-16',
     );
     expect(monthUtils.budgetColumnForCalendarMonth('2024-02', 'start')).toBe(
-      monthUtils.budgetMonthFromDate('2024-02-01'),
+      '2024-14',
+    );
+  });
+
+  it('addMonthsToDay preserves the day-of-month, clamping short months', () => {
+    expect(monthUtils.addMonthsToDay('2024-01-15', 1)).toBe('2024-02-15');
+    expect(monthUtils.addMonthsToDay('2024-01-31', 1)).toBe('2024-02-29');
+    expect(monthUtils.addMonthsToDay('2024-06-15', -3)).toBe('2024-03-15');
+  });
+
+  it('budgetColumnDistance fails loudly on a runaway pair', () => {
+    expect(() => monthUtils.budgetColumnDistance('2024-13', '2500-13')).toThrow(
+      /exceeds/,
     );
   });
 

--- a/packages/loot-core/src/shared/months.test.ts
+++ b/packages/loot-core/src/shared/months.test.ts
@@ -94,6 +94,41 @@ describe('pay period awareness', () => {
     expect(monthUtils.resolveStartMonth(undefined, '2024-13')).toBe('2024-13');
   });
 
+  it('budgetColumnDayRange returns the period days, not the calendar month days', () => {
+    // '2024-13' is Jan 5 - Jan 18 under this config. firstDayOfMonth would
+    // resolve the period to Jan 5 and then snap back to Jan 1.
+    expect(monthUtils.budgetColumnDayRange('2024-13')).toEqual({
+      start: '2024-01-05',
+      end: '2024-01-18',
+    });
+    expect(monthUtils.budgetColumnDayRange('2024-02')).toEqual({
+      start: '2024-02-01',
+      end: '2024-02-29',
+    });
+  });
+
+  it('budgetColumnDistance counts columns, and reports past targets as negative', () => {
+    expect(monthUtils.budgetColumnDistance('2024-13', '2024-13')).toBe(0);
+    expect(monthUtils.budgetColumnDistance('2024-13', '2024-16')).toBe(3);
+    expect(monthUtils.budgetColumnDistance('2024-16', '2024-13')).toBeLessThan(
+      0,
+    );
+    // Across a year boundary: the last period of 2024 to the first of 2025.
+    const lastOf2024 = monthUtils.getYearEnd('2024-13');
+    expect(monthUtils.budgetColumnDistance(lastOf2024, '2025-13')).toBe(1);
+  });
+
+  it('budgetColumnForCalendarMonth maps a calendar target onto a column', () => {
+    // A goal due "by February" may use every column February contains, so
+    // the deadline is the column holding Feb 29.
+    expect(monthUtils.budgetColumnForCalendarMonth('2024-02', 'end')).toBe(
+      monthUtils.budgetMonthFromDate('2024-02-29'),
+    );
+    expect(monthUtils.budgetColumnForCalendarMonth('2024-02', 'start')).toBe(
+      monthUtils.budgetMonthFromDate('2024-02-01'),
+    );
+  });
+
   it('resolveStartMonth rejects a period that the active cadence never generates', () => {
     // A biweekly year has 26-27 periods, so '2024-70' cannot exist even
     // though it is shaped like a pay period ID.
@@ -125,5 +160,23 @@ describe('pay period IDs without an active config', () => {
 
   it('budgetMonthFromDate falls back to the calendar month', () => {
     expect(monthUtils.budgetMonthFromDate('2024-01-10')).toBe('2024-01');
+  });
+
+  it('budget column helpers are calendar identities', () => {
+    expect(monthUtils.budgetColumnDayRange('2024-02')).toEqual({
+      start: '2024-02-01',
+      end: '2024-02-29',
+    });
+    expect(monthUtils.budgetColumnDistance('2024-01', '2024-04')).toBe(3);
+    expect(monthUtils.budgetColumnForCalendarMonth('2024-02', 'end')).toBe(
+      '2024-02',
+    );
+    expect(monthUtils.budgetColumnForCalendarMonth('2024-02', 'start')).toBe(
+      '2024-02',
+    );
+  });
+
+  it('getYearStart fails fast on a period ID', () => {
+    expect(() => monthUtils.getYearStart('2024-20')).toThrow(/no pay period/);
   });
 });

--- a/packages/loot-core/src/shared/months.test.ts
+++ b/packages/loot-core/src/shared/months.test.ts
@@ -93,6 +93,18 @@ describe('pay period awareness', () => {
     expect(monthUtils.resolveStartMonth('2024-01', '2024-13')).toBe('2024-13');
     expect(monthUtils.resolveStartMonth(undefined, '2024-13')).toBe('2024-13');
   });
+
+  it('resolveStartMonth rejects a period that the active cadence never generates', () => {
+    // A biweekly year has 26-27 periods, so '2024-70' cannot exist even
+    // though it is shaped like a pay period ID.
+    expect(monthUtils.resolveStartMonth('2024-70', '2024-13')).toBe('2024-13');
+
+    // Switching a stored weekly period to a monthly cadence: monthly only
+    // reaches '2024-24', so period 28 has to fall back.
+    setPayPeriodConfig({ payFrequency: 'monthly', startDate: '2024-01-15' });
+    expect(monthUtils.resolveStartMonth('2024-40', '2024-13')).toBe('2024-13');
+    expect(monthUtils.resolveStartMonth('2024-24', '2024-13')).toBe('2024-24');
+  });
 });
 
 describe('pay period IDs without an active config', () => {

--- a/packages/loot-core/src/shared/months.ts
+++ b/packages/loot-core/src/shared/months.ts
@@ -3,7 +3,10 @@ import * as d from 'date-fns';
 import type { Locale } from 'date-fns';
 
 import { memoizeOne } from '#shared/memoize';
-import { getPayPeriodConfig } from '#shared/pay-period-config';
+import {
+  getPayPeriodConfig,
+  payPeriodsActive,
+} from '#shared/pay-period-config';
 import {
   addPayPeriods,
   generatePayPeriods,
@@ -326,10 +329,12 @@ export function isAfter(month1: DateLike, month2: DateLike): boolean {
 }
 
 export function isCurrentMonth(month: DateLike): boolean {
-  const current = isPayPeriodValue(month)
-    ? currentBudgetMonth()
-    : currentMonth();
-  return month === current;
+  // Compare against the current budget column for the *active* mode, not for
+  // whatever shape the argument happens to have: every caller uses this to
+  // highlight the current budget column, and while pay periods are on a
+  // calendar month is never that column — deciding by the argument's shape
+  // let a stale calendar ID light up as "current".
+  return month === currentBudgetMonth();
 }
 
 /**
@@ -394,6 +399,92 @@ export function bounds(month: DateLike): { start: number; end: number } {
     start: parseInt(d.format(d.startOfMonth(_parse(month)), 'yyyyMMdd')),
     end: parseInt(d.format(d.endOfMonth(_parse(month)), 'yyyyMMdd')),
   };
+}
+
+/**
+ * The first and last day (`yyyy-MM-dd`) covered by a budget column: the pay
+ * period's own day range while pay periods are active, the calendar month's
+ * otherwise.
+ *
+ * Use this — never `firstDayOfMonth`/`lastDayOfMonth` — whenever the value
+ * is a budget *column* rather than a calendar month. `firstDayOfMonth`
+ * resolves a period ID to the period's start date and then snaps to the
+ * start of that calendar month, which is a different day.
+ */
+export function budgetColumnDayRange(month: string): {
+  start: string;
+  end: string;
+} {
+  if (isPayPeriodValue(month)) {
+    const { startDate, endDate } = getPayPeriodBounds(
+      month,
+      requirePayPeriodConfig(month),
+    );
+    return { start: startDate, end: endDate };
+  }
+  return { start: firstDayOfMonth(month), end: lastDayOfMonth(month) };
+}
+
+// Guards the budget column walk below against a malformed pair (e.g. a
+// target month far outside the budget) spinning forever.
+const MAX_BUDGET_COLUMN_DISTANCE = 10000;
+
+/**
+ * Distance from one budget column to another, measured in budget columns.
+ *
+ * With pay periods several columns can share a calendar month, so a
+ * calendar-month distance reports 0 for every column of that month — and a
+ * goal that divides by it then funds itself in full in each one. `nextMonth`
+ * steps pay periods while they are active, so counting steps is correct in
+ * both modes; in calendar mode the count is the calendar-month difference.
+ *
+ * Negative distances are reported as -1: callers only test them for sign
+ * (a target already in the past), so there is no need to walk backwards.
+ */
+export function budgetColumnDistance(from: string, to: string): number {
+  if (!payPeriodsActive()) {
+    return differenceInCalendarMonths(to, from);
+  }
+  if (to === from) {
+    return 0;
+  }
+  if (to < from) {
+    return -1;
+  }
+
+  let distance = 0;
+  let column = from;
+  while (column < to && distance < MAX_BUDGET_COLUMN_DISTANCE) {
+    column = nextMonth(column);
+    distance += 1;
+  }
+  return distance;
+}
+
+/**
+ * The budget column that a calendar month's first or last day falls in.
+ *
+ * Goal templates state their windows in calendar terms ("by August", "from
+ * March") no matter what the budget column cadence is, so those months have
+ * to be mapped onto columns before any column arithmetic. Identity when pay
+ * periods are off.
+ *
+ * `edge: 'end'` is the right choice for a deadline — a goal due "by August"
+ * may use every column that August contains — and `'start'` for the opening
+ * of a window.
+ */
+export function budgetColumnForCalendarMonth(
+  calendarMonth: string,
+  edge: 'start' | 'end',
+): string {
+  if (!payPeriodsActive()) {
+    return calendarMonth;
+  }
+  return budgetMonthFromDate(
+    edge === 'end'
+      ? lastDayOfMonth(calendarMonth)
+      : firstDayOfMonth(calendarMonth),
+  );
 }
 
 export function _yearRange(
@@ -555,6 +646,11 @@ export function getWeekEnd(
 
 export function getYearStart(month: string): string {
   if (isPayPeriod(month)) {
+    // The first period of a year is always '-13', so this needs no config to
+    // compute — but a period ID reaching here while pay periods are off means
+    // a stale ID leaked in from the other mode, and returning another period
+    // ID would carry it further. Fail the same way getYearEnd does.
+    requirePayPeriodConfig(month);
     return getYear(month) + '-13';
   }
   return getYear(month) + '-01';

--- a/packages/loot-core/src/shared/months.ts
+++ b/packages/loot-core/src/shared/months.ts
@@ -283,6 +283,20 @@ export function addWeeks(date: DateLike, n: number): string {
   return d.format(d.addWeeks(_parse(date), n), 'yyyy-MM-dd');
 }
 
+/**
+ * Shifts a day by whole calendar months, preserving the day-of-month
+ * (clamped in shorter months: Jan 31 + 1 month = Feb 28/29).
+ *
+ * `addMonths` cannot be used for this: it returns a 'yyyy-MM' month, and
+ * re-parsing that loses the day — every step snaps to the 1st. That is
+ * harmless when the consumer only cares which calendar month the result is
+ * in, but a budget column can start mid-month (a pay period), where the
+ * 1st and the anchor day can fall in different columns.
+ */
+export function addMonthsToDay(day: DateLike, n: number): string {
+  return d.format(d.addMonths(_parse(day), n), 'yyyy-MM-dd');
+}
+
 export function differenceInCalendarMonths(
   month1: DateLike,
   month2: DateLike,
@@ -429,17 +443,35 @@ export function budgetColumnDayRange(month: string): {
 // target month far outside the budget) spinning forever.
 const MAX_BUDGET_COLUMN_DISTANCE = 10000;
 
+function countColumnSteps(from: string, to: string): number {
+  let distance = 0;
+  let column = from;
+  while (column < to) {
+    if (distance >= MAX_BUDGET_COLUMN_DISTANCE) {
+      // Failing loudly beats returning the cap as though it were a real
+      // distance — callers divide by this value.
+      throw new Error(
+        `Budget column distance from '${from}' to '${to}' exceeds ` +
+          `${MAX_BUDGET_COLUMN_DISTANCE} columns; the pair is likely malformed`,
+      );
+    }
+    column = nextMonth(column);
+    distance += 1;
+  }
+  return distance;
+}
+
 /**
  * Distance from one budget column to another, measured in budget columns.
+ * Negative when `to` is before `from`, exactly like the calendar-month
+ * difference — callers divide by these spans, so the sign and the magnitude
+ * both have to be real.
  *
  * With pay periods several columns can share a calendar month, so a
  * calendar-month distance reports 0 for every column of that month — and a
  * goal that divides by it then funds itself in full in each one. `nextMonth`
  * steps pay periods while they are active, so counting steps is correct in
  * both modes; in calendar mode the count is the calendar-month difference.
- *
- * Negative distances are reported as -1: callers only test them for sign
- * (a target already in the past), so there is no need to walk backwards.
  */
 export function budgetColumnDistance(from: string, to: string): number {
   if (!payPeriodsActive()) {
@@ -448,17 +480,9 @@ export function budgetColumnDistance(from: string, to: string): number {
   if (to === from) {
     return 0;
   }
-  if (to < from) {
-    return -1;
-  }
-
-  let distance = 0;
-  let column = from;
-  while (column < to && distance < MAX_BUDGET_COLUMN_DISTANCE) {
-    column = nextMonth(column);
-    distance += 1;
-  }
-  return distance;
+  // Within one mode the IDs order lexicographically, so this picks the
+  // walking direction.
+  return to < from ? -countColumnSteps(to, from) : countColumnSteps(from, to);
 }
 
 /**

--- a/packages/loot-core/src/shared/months.ts
+++ b/packages/loot-core/src/shared/months.ts
@@ -333,11 +333,19 @@ export function isCurrentMonth(month: DateLike): boolean {
 }
 
 /**
- * Sanitizes a persisted budget start month (the `budget.startMonth` local
- * pref) against the active mode: a stored pay period ID is only valid
- * while pay periods are active, and vice versa. Returns `fallback`
- * (typically `currentBudgetMonth()`) when the stored value belongs to the
- * other mode — e.g. right after toggling pay periods on or off.
+ * Sanitizes a persisted budget month (the `budget.startMonth` local pref, a
+ * month in a URL) against the active configuration. Returns `fallback`
+ * (typically `currentBudgetMonth()`) when the stored value can't be a
+ * budget column right now, which happens in three ways:
+ *
+ * - a pay period was stored but pay periods are now off,
+ * - a calendar month was stored but pay periods are now on,
+ * - a pay period was stored and pay periods are still on, but the cadence
+ *   changed and that period no longer exists — e.g. '2026-40' is period 28
+ *   of a weekly year, and a monthly cadence only reaches '2026-24'.
+ *
+ * The third case is the subtle one: the ID still looks like a pay period,
+ * so a kind check alone lets it through to a sheet that was never created.
  */
 export function resolveStartMonth(
   stored: string | undefined,
@@ -346,8 +354,23 @@ export function resolveStartMonth(
   if (!stored) {
     return fallback;
   }
-  const active = getPayPeriodConfig() != null;
-  return isPayPeriod(stored) === active ? stored : fallback;
+
+  const config = getPayPeriodConfig();
+  if (isPayPeriod(stored) !== (config != null)) {
+    return fallback;
+  }
+  if (config && !periodExists(stored, config)) {
+    return fallback;
+  }
+  return stored;
+}
+
+function periodExists(monthId: string, config: PayPeriodConfig): boolean {
+  const year = Number(getYear(monthId));
+  if (Number.isNaN(year)) {
+    return false;
+  }
+  return generatePayPeriods(year, config).some(p => p.monthId === monthId);
 }
 
 export function isCurrentDay(day: DateLike): boolean {

--- a/packages/loot-core/src/types/server-events.ts
+++ b/packages/loot-core/src/types/server-events.ts
@@ -60,6 +60,12 @@ type OrphanedPayeesEvent = {
   updatedPayeeIds: string[];
 };
 
+// The active pay period configuration changed server-side (a local save, a
+// change synced from another device or tab, or an undo). The client must
+// re-read the synced prefs so its own registry — and the budget columns it
+// derives from it — follow the new cadence.
+type PayPeriodConfigChangedEvent = undefined;
+
 type PrefsUpdatedEvent = undefined;
 type SchedulesOfflineEvent = undefined;
 type ServerErrorEvent = undefined;
@@ -76,6 +82,7 @@ export type ServerEvents = {
   'finish-load': FinishLoadEvent;
   'indexeddb-quota-error': IndexeddbQuotaErrorEvent;
   'orphaned-payees': OrphanedPayeesEvent;
+  'pay-period-config-changed': PayPeriodConfigChangedEvent;
   'prefs-updated': PrefsUpdatedEvent;
   'schedules-offline': SchedulesOfflineEvent;
   'server-error': ServerErrorEvent;

--- a/upcoming-release-notes/fix-pay-period-budget-page-switch.md
+++ b/upcoming-release-notes/fix-pay-period-budget-page-switch.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [code-with-jov]
+---
+
+Fix the budget page breaking when the pay period setting changes from another device or is undone

--- a/upcoming-release-notes/fix-pay-period-goal-templates-and-reports.md
+++ b/upcoming-release-notes/fix-pay-period-goal-templates-and-reports.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [code-with-jov]
----
-
-Fix goal templates budgeting the wrong amount (or nothing at all) while budgeting by pay period, stop the budget page crashing when the pay period setting changes in another tab or is undone, and hide the Spending report's "Budgeted" comparison, which has no data in pay period mode.

--- a/upcoming-release-notes/fix-pay-period-goal-templates-and-reports.md
+++ b/upcoming-release-notes/fix-pay-period-goal-templates-and-reports.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [code-with-jov]
+---
+
+Fix goal templates budgeting the wrong amount (or nothing at all) while budgeting by pay period, stop the budget page crashing when the pay period setting changes in another tab or is undone, and hide the Spending report's "Budgeted" comparison, which has no data in pay period mode.

--- a/upcoming-release-notes/fix-pay-period-goal-templates.md
+++ b/upcoming-release-notes/fix-pay-period-goal-templates.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [code-with-jov]
+---
+
+Fix goal templates budgeting the wrong amount, or nothing at all, while budgeting by pay period

--- a/upcoming-release-notes/fix-undo-first-preference-change.md
+++ b/upcoming-release-notes/fix-undo-first-preference-change.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [code-with-jov]
+---
+
+Fix an error when undoing or redoing a change to a setting that had not been changed before

--- a/upcoming-release-notes/pay-period-budget-reports-unavailable.md
+++ b/upcoming-release-notes/pay-period-budget-reports-unavailable.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [code-with-jov]
+---
+
+Show a clear message instead of an empty chart when a budget report can't be shown while budgeting by pay period

--- a/upcoming-release-notes/pay-period-budget-reports-unavailable.md
+++ b/upcoming-release-notes/pay-period-budget-reports-unavailable.md
@@ -3,4 +3,4 @@ category: Bugfix
 authors: [code-with-jov]
 ---
 
-Show a clear message instead of an empty chart when a budget report can't be shown while budgeting by pay period
+Show a message instead of a chart of zeroes when a budget report has no data while budgeting by pay period

--- a/upcoming-release-notes/pay-period-spending-report-mode.md
+++ b/upcoming-release-notes/pay-period-spending-report-mode.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [code-with-jov]
+---
+
+Disable report comparisons that rely on monthly budgets while budgeting by pay period, instead of showing zeroes


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->