### PR TITLE
[AI] Rename Cloudflare preview project to actual-pay-periods, add demo link

### DIFF
--- a/.github/workflows/personal-preview.yml
+++ b/.github/workflows/personal-preview.yml
@@ -23,7 +23,7 @@ on:
       project_name:
         description: 'Cloudflare Pages project name'
         type: string
-        default: actual-preview
+        default: actual-pay-periods
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
   <img src="/demo.png" alt="Actualbudget" />
 </p>
 
+<p align="center">
+  <a href="https://develop.actual-pay-periods.pages.dev/budget">Live Demo</a>
+</p>
+
 ## Getting Started
 
 Actual is a local-first personal finance tool. It is 100% free and open-source, written in NodeJS, it has a synchronization element so that all your changes can move between devices without any heavy lifting.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="https://develop.actual-pay-periods.pages.dev/budget">Live Demo</a>
+  <a href="https://develop.actual-pay-periods.pages.dev/budget">Live Pay Period Demo</a>
 </p>
 
 ## Getting Started


### PR DESCRIPTION
Updates the personal-preview workflow's dispatch input default from
actual-preview to actual-pay-periods to match the fork's branding, and
adds a live demo link to the top of the README.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014zGp6K8dK2L5Cr6p1ZYi2G