### PR TITLE
[AI] Toggle pay periods from the budget page

### DIFF
--- a/packages/desktop-client/e2e/page-models/settings-page.ts
+++ b/packages/desktop-client/e2e/page-models/settings-page.ts
@@ -69,4 +69,34 @@ export class SettingsPage {
       await expect(featureCheckbox).toBeChecked({ timeout: 2000 });
     }).toPass({ timeout: 15000 });
   }
+
+  async disableExperimentalFeature(featureName: string) {
+    await this.advancedSettingsButton.waitFor({
+      state: 'visible',
+      timeout: 2000,
+    });
+    await this.advancedSettingsButton.click();
+
+    await this.experimentalSettingsButton.waitFor({
+      state: 'visible',
+      timeout: 2000,
+    });
+    await this.experimentalSettingsButton.click();
+
+    const featureCheckbox = this.page.getByRole('checkbox', {
+      name: featureName,
+    });
+    await featureCheckbox.waitFor({ state: 'visible' });
+    // Mirror of enableExperimentalFeature: the click can race a settings
+    // re-render and get lost, so retry until the checkbox reflects it.
+    await expect(async () => {
+      if (await featureCheckbox.isChecked()) {
+        await featureCheckbox.click();
+      }
+      await expect(featureCheckbox).toBeChecked({
+        checked: false,
+        timeout: 2000,
+      });
+    }).toPass({ timeout: 15000 });
+  }
 }

--- a/packages/desktop-client/e2e/pay-period-helpers.ts
+++ b/packages/desktop-client/e2e/pay-period-helpers.ts
@@ -19,8 +19,12 @@ export const PREVIOUS_PERIOD = '2016-38';
 export const PREVIOUS_PERIOD_LABEL = 'Dec 18 - Dec 31';
 export const CURRENT_CALENDAR_MONTH = '2017-01';
 
-export function getPayPeriodCheckbox(page: Page) {
-  return page.getByRole('checkbox', { name: 'Budget by pay period' });
+/**
+ * The toggle button in the budget page's month picker (desktop only —
+ * mobile toggles through the budget page menu instead).
+ */
+export function getPayPeriodToggle(page: Page) {
+  return page.getByRole('button', { name: 'Toggle pay period budgeting' });
 }
 
 export async function selectPayFrequency(page: Page, frequencyLabel: string) {
@@ -33,48 +37,53 @@ export async function selectPayFrequency(page: Page, frequencyLabel: string) {
 }
 
 /**
- * Toggles the "Budget by pay period" checkbox into the desired state.
- *
- * The control is disabled for as long as the save is in flight — the server
- * cold-builds every budget column for the new mode before the pref save
- * resolves — so one click is enough; just wait for it to come back.
+ * Fill in the biweekly cadence on the settings page without enabling it —
+ * enabling now happens from the budget page. Assumes the pay period
+ * settings section is already visible (i.e. the 'Pay periods' feature flag
+ * is enabled).
  */
-export async function togglePayPeriods(page: Page, enabled: boolean) {
-  const checkbox = getPayPeriodCheckbox(page);
-  await expect(checkbox).toBeEnabled();
-
-  if ((await checkbox.isChecked()) === enabled) {
-    return;
-  }
-
-  await checkbox.click();
-  await expect(checkbox).toBeChecked({ checked: enabled, timeout: 60000 });
-  await expect(checkbox).toBeEnabled({ timeout: 60000 });
-}
-
-/**
- * Configure a biweekly pay period cadence and turn on pay period budgeting.
- * Assumes the pay period settings section is already visible (i.e. the 'Pay
- * periods' feature flag is enabled).
- *
- * Also activates the same cadence in the *test* process, so that helpers
- * which call `monthUtils` here — rather than driving the UI — resolve period
- * IDs instead of throwing `no pay period configuration is active`. Both come
- * from the constants above, so the test's view of the cadence cannot drift
- * from what the app was configured with. Pair with
- * `resetPayPeriodConfigForTesting()` in an afterEach.
- */
-export async function configureAndEnablePayPeriods(page: Page) {
+export async function configurePayPeriodPrefs(page: Page) {
   await selectPayFrequency(page, PAY_PERIOD_FREQUENCY_LABEL);
   const startDateInput = page.locator('#pay-period-start-date');
   await startDateInput.fill(PAY_PERIOD_START_DATE);
   // The date field commits on blur/Enter rather than per keystroke, so the
   // fill alone doesn't save the pref.
   await startDateInput.press('Enter');
-  await togglePayPeriods(page, true);
+}
 
+/**
+ * Activate the same cadence in the *test* process, so that helpers which
+ * call `monthUtils` here — rather than driving the UI — resolve period IDs
+ * instead of throwing `no pay period configuration is active`. The values
+ * come from the constants above, so the test's view of the cadence cannot
+ * drift from what the app was configured with. Pair with
+ * `resetPayPeriodConfigForTesting()` in an afterEach.
+ */
+export function activatePayPeriodConfigForTestProcess() {
   setPayPeriodConfig({
     payFrequency: 'biweekly',
     startDate: PAY_PERIOD_START_DATE,
   });
+}
+
+/**
+ * Toggle pay periods from the desktop budget page's month picker and wait
+ * for the budget to settle in the target cadence. The server cold-builds
+ * every budget column for the new mode before the pref save resolves, and
+ * the page re-initializes behind a spinner after that, so the settled
+ * month picker is the signal that the switch is complete.
+ */
+export async function togglePayPeriodsFromBudgetPage(
+  page: Page,
+  enabled: boolean,
+) {
+  const toggle = getPayPeriodToggle(page);
+  await expect(toggle).toBeVisible();
+  await toggle.click();
+
+  await expect(page.getByTestId('selected-budget-month')).toHaveAttribute(
+    'data-month',
+    enabled ? CURRENT_PERIOD : CURRENT_CALENDAR_MONTH,
+    { timeout: 60000 },
+  );
 }

--- a/packages/desktop-client/e2e/pay-periods.mobile.test.ts
+++ b/packages/desktop-client/e2e/pay-periods.mobile.test.ts
@@ -7,12 +7,33 @@ import { ConfigurationPage } from './page-models/configuration-page';
 import type { MobileBudgetPage } from './page-models/mobile-budget-page';
 import { MobileNavigation } from './page-models/mobile-navigation';
 import {
-  configureAndEnablePayPeriods,
+  activatePayPeriodConfigForTestProcess,
+  configurePayPeriodPrefs,
+  CURRENT_CALENDAR_MONTH,
   CURRENT_PERIOD,
   CURRENT_PERIOD_LABEL,
   PREVIOUS_PERIOD,
   PREVIOUS_PERIOD_LABEL,
 } from './pay-period-helpers';
+
+/**
+ * Enable pay periods from the budget page menu — the mobile counterpart of
+ * the desktop month picker toggle. Selecting the item closes the menu, and
+ * the server rebuilds every budget sheet before the heading settles on the
+ * current period.
+ */
+async function enablePayPeriodsFromMenu(
+  page: Page,
+  budgetPage: MobileBudgetPage,
+) {
+  await budgetPage.openBudgetPageMenu();
+  await page.getByText('Enable pay period budgeting', { exact: true }).click();
+  await expect(budgetPage.heading.locator('[data-month]')).toHaveAttribute(
+    'data-month',
+    CURRENT_PERIOD,
+    { timeout: 60000 },
+  );
+}
 
 test.describe('Mobile Budget in pay period mode', () => {
   let page: Page;
@@ -50,21 +71,31 @@ test.describe('Mobile Budget in pay period mode', () => {
 
     const settingsPage = await navigation.goToSettingsPage();
     await settingsPage.enableExperimentalFeature('Pay periods');
-    await configureAndEnablePayPeriods(page);
+    await configurePayPeriodPrefs(page);
 
     budgetPage = await navigation.goToBudgetPage();
-    // Enabling pay periods rebuilds the budget cache for every period
-    // sheet, so give the mode switch extra time to settle under CI load.
-    await expect(budgetPage.heading.locator('[data-month]')).toHaveAttribute(
-      'data-month',
-      CURRENT_PERIOD,
-      { timeout: 30000 },
-    );
+    await enablePayPeriodsFromMenu(page, budgetPage);
+    activatePayPeriodConfigForTestProcess();
   });
 
   test.afterEach(async () => {
     resetPayPeriodConfigForTesting();
     await page.close();
+  });
+
+  test('disabling pay periods from the menu returns to calendar months', async () => {
+    await budgetPage.openBudgetPageMenu();
+    await page
+      .getByText('Disable pay period budgeting', { exact: true })
+      .click();
+
+    // Disabling rebuilds the sheets back to calendar months; the stale pay
+    // period start month must resolve to the current calendar month.
+    await expect(budgetPage.heading.locator('[data-month]')).toHaveAttribute(
+      'data-month',
+      CURRENT_CALENDAR_MONTH,
+      { timeout: 60000 },
+    );
   });
 
   test('budget page heading shows the current pay period date range', async () => {
@@ -245,14 +276,11 @@ test.describe('Mobile Tracking budget in pay period mode', () => {
     const settingsPage = await navigation.goToSettingsPage();
     await settingsPage.useBudgetType('Tracking');
     await settingsPage.enableExperimentalFeature('Pay periods');
-    await configureAndEnablePayPeriods(page);
+    await configurePayPeriodPrefs(page);
 
     budgetPage = await navigation.goToBudgetPage();
-    await expect(budgetPage.heading.locator('[data-month]')).toHaveAttribute(
-      'data-month',
-      CURRENT_PERIOD,
-      { timeout: 30000 },
-    );
+    await enablePayPeriodsFromMenu(page, budgetPage);
+    activatePayPeriodConfigForTestProcess();
   });
 
   test.afterEach(async () => {

--- a/packages/desktop-client/e2e/pay-periods.test.ts
+++ b/packages/desktop-client/e2e/pay-periods.test.ts
@@ -6,19 +6,18 @@ import type { BudgetPage } from './page-models/budget-page';
 import { ConfigurationPage } from './page-models/configuration-page';
 import { Navigation } from './page-models/navigation';
 import {
-  configureAndEnablePayPeriods,
+  activatePayPeriodConfigForTestProcess,
+  configurePayPeriodPrefs,
   CURRENT_CALENDAR_MONTH,
   CURRENT_PERIOD,
   CURRENT_PERIOD_LABEL,
-  getPayPeriodCheckbox,
+  getPayPeriodToggle,
   NEXT_PERIOD,
   NEXT_PERIOD_LABEL,
-  PAY_PERIOD_FREQUENCY_LABEL,
   PAY_PERIOD_START_DATE,
   PREVIOUS_PERIOD,
   PREVIOUS_PERIOD_LABEL,
-  selectPayFrequency,
-  togglePayPeriods,
+  togglePayPeriodsFromBudgetPage,
 } from './pay-period-helpers';
 
 test.describe('Pay period settings', () => {
@@ -46,74 +45,67 @@ test.describe('Pay period settings', () => {
     await page?.close();
   });
 
-  test('pay period settings are hidden until the feature flag is enabled', async () => {
+  test('pay period settings and toggle are hidden until the feature flag is enabled', async () => {
+    // Without the flag neither the settings section nor the budget page
+    // toggle exists.
+    let budgetPage = await navigation.goToBudgetPage();
+    await budgetPage.waitFor();
+    await expect(getPayPeriodToggle(page)).toHaveCount(0);
+
     const settingsPage = await navigation.goToSettingsPage();
     await settingsPage.waitFor();
-
-    await expect(getPayPeriodCheckbox(page)).toHaveCount(0);
+    await expect(page.locator('#pay-period-frequency')).toHaveCount(0);
 
     await settingsPage.enableExperimentalFeature('Pay periods');
 
-    await expect(getPayPeriodCheckbox(page)).toBeVisible();
+    // The settings only carry the configuration — the on/off toggle lives
+    // on the budget page.
+    await expect(page.locator('#pay-period-frequency')).toBeVisible();
+    await expect(
+      page.getByRole('checkbox', { name: 'Budget by pay period' }),
+    ).toHaveCount(0);
+
+    budgetPage = await navigation.goToBudgetPage();
+    await budgetPage.waitFor();
+    await expect(getPayPeriodToggle(page)).toBeVisible();
   });
 
-  test('budget by pay period stays disabled until the configuration is valid', async () => {
+  test('enabling from the budget page without a configuration defaults to monthly periods', async () => {
     const settingsPage = await navigation.goToSettingsPage();
     await settingsPage.enableExperimentalFeature('Pay periods');
 
-    const checkbox = getPayPeriodCheckbox(page);
-    await expect(checkbox).toBeDisabled();
-    await expect(
-      page.getByText(
-        'Choose a pay frequency and a payday date to enable pay periods.',
-      ),
-    ).toBeVisible();
+    const budgetPage = await navigation.goToBudgetPage();
+    await budgetPage.waitFor();
 
-    // A frequency alone is not enough — a payday date is also required.
-    await selectPayFrequency(page, PAY_PERIOD_FREQUENCY_LABEL);
-    await expect(checkbox).toBeDisabled();
+    // No frequency or payday has been configured; the toggle fills in a
+    // monthly cadence anchored on the first of the current month, so under
+    // the pinned 2017-01-01 clock the current period is still '2017-13'.
+    await togglePayPeriodsFromBudgetPage(page, true);
 
-    // The date commits on blur/Enter, not per keystroke — a native date
-    // input emits "valid" partial values while the year is being typed.
-    const startDateInput = page.locator('#pay-period-start-date');
-    await startDateInput.fill(PAY_PERIOD_START_DATE);
-    await expect(checkbox).toBeDisabled();
-    await startDateInput.press('Enter');
-    await expect(checkbox).toBeEnabled();
-
-    // The click is only acknowledged once the server has rebuilt the
-    // budget sheets for the new mode.
-    await checkbox.click();
-    await expect(checkbox).toBeChecked({ timeout: 60000 });
-    await expect(checkbox).toBeEnabled({ timeout: 60000 });
+    // The defaults surface in the settings, ready to be refined.
+    await navigation.goToSettingsPage();
+    await expect(page.locator('#pay-period-frequency')).toHaveText('Monthly');
+    await expect(page.locator('#pay-period-start-date')).toHaveValue(
+      PAY_PERIOD_START_DATE,
+    );
   });
 
   test('disabling pay periods returns the budget page to calendar months', async () => {
     const settingsPage = await navigation.goToSettingsPage();
     await settingsPage.enableExperimentalFeature('Pay periods');
-    await configureAndEnablePayPeriods(page);
+    await configurePayPeriodPrefs(page);
 
-    // The budget page starts on the current pay period. Toggling pay
-    // periods rebuilds the budget cache for every period sheet, so give
-    // the mode switch extra time to settle under CI load.
-    let budgetPage = await navigation.goToBudgetPage();
-    await expect(budgetPage.selectedMonthButton).toHaveAttribute(
-      'data-month',
-      CURRENT_PERIOD,
-      { timeout: 60000 },
-    );
+    // Toggling pay periods rebuilds the budget cache for every period
+    // sheet, so give the mode switch extra time to settle under CI load.
+    const budgetPage = await navigation.goToBudgetPage();
+    await budgetPage.waitFor();
+    await togglePayPeriodsFromBudgetPage(page, true);
+    activatePayPeriodConfigForTestProcess();
 
     // Turn pay periods back off; the stale pay period start month must be
     // resolved back to the current calendar month without crashing.
-    await navigation.goToSettingsPage();
-    await togglePayPeriods(page, false);
+    await togglePayPeriodsFromBudgetPage(page, false);
 
-    budgetPage = await navigation.goToBudgetPage();
-    await expect(budgetPage.selectedMonthButton).toHaveAttribute(
-      'data-month',
-      CURRENT_CALENDAR_MONTH,
-      { timeout: 60000 },
-    );
     // The visible summary is the second one in the DOM — BudgetSummaries
     // renders an off-screen summary on each side for scroll animations.
     await expect(
@@ -121,28 +113,30 @@ test.describe('Pay period settings', () => {
     ).toBeVisible();
   });
 
-  test('undoing the pay period toggle keeps the UI in sync with the server', async () => {
+  test('undoing the toggle while away from the budget page keeps the UI in sync', async () => {
     const settingsPage = await navigation.goToSettingsPage();
     await settingsPage.enableExperimentalFeature('Pay periods');
-    await configureAndEnablePayPeriods(page);
+    await configurePayPeriodPrefs(page);
 
-    const checkbox = getPayPeriodCheckbox(page);
+    let budgetPage = await navigation.goToBudgetPage();
+    await budgetPage.waitFor();
+    await togglePayPeriodsFromBudgetPage(page, true);
+    activatePayPeriodConfigForTestProcess();
 
     // Undo reverts the preference server-side, which rebuilds the budget
     // sheets back to calendar months. The client is told about it and must
-    // follow — otherwise the checkbox would keep claiming pay periods are
-    // on and the budget page would ask for sheets that no longer exist.
-    // The global Ctrl+Z handler ignores the shortcut while an input has
-    // focus, and the toggle click left the checkbox focused.
+    // follow — otherwise the budget page would ask for sheets that no
+    // longer exist. Undo from the settings route, so the change lands
+    // while the budget page is unmounted. The global Ctrl+Z handler
+    // ignores the shortcut while an input has focus, and the toggle click
+    // left the toggle button focused.
+    await navigation.goToSettingsPage();
     await page.evaluate(() => {
       (document.activeElement as HTMLElement | null)?.blur();
     });
     await page.keyboard.press('Control+z');
 
-    await expect(checkbox).toBeChecked({ checked: false, timeout: 60000 });
-    await expect(checkbox).toBeEnabled({ timeout: 60000 });
-
-    const budgetPage = await navigation.goToBudgetPage();
+    budgetPage = await navigation.goToBudgetPage();
     await expect(budgetPage.selectedMonthButton).toHaveAttribute(
       'data-month',
       CURRENT_CALENDAR_MONTH,
@@ -181,14 +175,12 @@ test.describe('Pay period settings', () => {
   test('changing the cadence while the budget page is open does not break it', async () => {
     const settingsPage = await navigation.goToSettingsPage();
     await settingsPage.enableExperimentalFeature('Pay periods');
-    await configureAndEnablePayPeriods(page);
+    await configurePayPeriodPrefs(page);
 
     const budgetPage = await navigation.goToBudgetPage();
-    await expect(budgetPage.selectedMonthButton).toHaveAttribute(
-      'data-month',
-      CURRENT_PERIOD,
-      { timeout: 60000 },
-    );
+    await budgetPage.waitFor();
+    await togglePayPeriodsFromBudgetPage(page, true);
+    activatePayPeriodConfigForTestProcess();
 
     // Undo the preference without leaving the page. The global handler
     // ignores the shortcut while an input has focus.
@@ -239,16 +231,14 @@ test.describe('Budget in pay period mode', () => {
 
     const settingsPage = await navigation.goToSettingsPage();
     await settingsPage.enableExperimentalFeature('Pay periods');
-    await configureAndEnablePayPeriods(page);
+    await configurePayPeriodPrefs(page);
 
     budgetPage = await navigation.goToBudgetPage();
+    await budgetPage.waitFor();
     // Enabling pay periods rebuilds the budget cache for every period
-    // sheet, so give the mode switch extra time to settle under CI load.
-    await expect(budgetPage.selectedMonthButton).toHaveAttribute(
-      'data-month',
-      CURRENT_PERIOD,
-      { timeout: 30000 },
-    );
+    // sheet; the toggle helper waits for the mode switch to settle.
+    await togglePayPeriodsFromBudgetPage(page, true);
+    activatePayPeriodConfigForTestProcess();
 
     // Move mouse to corner of the screen; sometimes the mouse hovers on a
     // budget element thus rendering an input box and this breaks tests.

--- a/packages/desktop-client/e2e/pay-periods.test.ts
+++ b/packages/desktop-client/e2e/pay-periods.test.ts
@@ -113,7 +113,7 @@ test.describe('Pay period settings', () => {
     ).toBeVisible();
   });
 
-  test('undoing the toggle while away from the budget page keeps the UI in sync', async () => {
+  test('deactivating pay periods away from the budget page keeps the UI in sync', async () => {
     const settingsPage = await navigation.goToSettingsPage();
     await settingsPage.enableExperimentalFeature('Pay periods');
     await configurePayPeriodPrefs(page);
@@ -123,18 +123,15 @@ test.describe('Pay period settings', () => {
     await togglePayPeriodsFromBudgetPage(page, true);
     activatePayPeriodConfigForTestProcess();
 
-    // Undo reverts the preference server-side, which rebuilds the budget
-    // sheets back to calendar months. The client is told about it and must
-    // follow — otherwise the budget page would ask for sheets that no
-    // longer exist. Undo from the settings route, so the change lands
-    // while the budget page is unmounted. The global Ctrl+Z handler
-    // ignores the shortcut while an input has focus, and the toggle click
-    // left the toggle button focused.
+    // Turn the experimental feature itself off from the settings route.
+    // That deactivates the configuration and rebuilds the budget sheets
+    // back to calendar months while the budget page is unmounted; the
+    // remount must follow the server — otherwise it would ask for sheets
+    // that no longer exist. The pay period section unmounting is the proof
+    // that the flag change landed client-side.
     await navigation.goToSettingsPage();
-    await page.evaluate(() => {
-      (document.activeElement as HTMLElement | null)?.blur();
-    });
-    await page.keyboard.press('Control+z');
+    await settingsPage.disableExperimentalFeature('Pay periods');
+    await expect(page.locator('#pay-period-frequency')).toHaveCount(0);
 
     budgetPage = await navigation.goToBudgetPage();
     await expect(budgetPage.selectedMonthButton).toHaveAttribute(

--- a/packages/desktop-client/src/components/budget/BudgetPageHeader.tsx
+++ b/packages/desktop-client/src/components/budget/BudgetPageHeader.tsx
@@ -14,10 +14,21 @@ type BudgetPageHeaderProps = {
   onMonthSelect: (month: string) => void;
   numMonths: number;
   monthBounds: ComponentProps<typeof MonthPicker>['monthBounds'];
+  onTogglePayPeriods?: () => void;
+  payPeriodsActive?: boolean;
+  payPeriodsToggleDisabled?: boolean;
 };
 
 export const BudgetPageHeader = memo<BudgetPageHeaderProps>(
-  ({ startMonth, onMonthSelect, numMonths, monthBounds }) => {
+  ({
+    startMonth,
+    onMonthSelect,
+    numMonths,
+    monthBounds,
+    onTogglePayPeriods,
+    payPeriodsActive,
+    payPeriodsToggleDisabled,
+  }) => {
     const [categoryExpandedStatePref] = useGlobalPref('categoryExpandedState');
     const categoryExpandedState = categoryExpandedStatePref ?? 0;
     const offsetMultipleMonths = numMonths === 1 ? 4 : 0;
@@ -41,6 +52,9 @@ export const BudgetPageHeader = memo<BudgetPageHeaderProps>(
             monthBounds={monthBounds}
             style={{ paddingTop: 5 }}
             onSelect={month => onMonthSelect(month)}
+            onTogglePayPeriods={onTogglePayPeriods}
+            payPeriodsActive={payPeriodsActive}
+            payPeriodsToggleDisabled={payPeriodsToggleDisabled}
           />
         </View>
       </View>

--- a/packages/desktop-client/src/components/budget/DynamicBudgetTable.tsx
+++ b/packages/desktop-client/src/components/budget/DynamicBudgetTable.tsx
@@ -11,6 +11,7 @@ import * as monthUtils from '@actual-app/core/shared/months';
 import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { useFeatureFlag } from '#hooks/useFeatureFlag';
 import { useGlobalPref } from '#hooks/useGlobalPref';
+import { useTogglePayPeriods } from '#hooks/useTogglePayPeriods';
 
 import { useBudgetMonthCount } from './BudgetMonthCountContext';
 import { BudgetPageHeader } from './BudgetPageHeader';
@@ -54,6 +55,9 @@ const DynamicBudgetTable = ({
   const { setDisplayMax } = useBudgetMonthCount();
   const [categoryExpandedStatePref] = useGlobalPref('categoryExpandedState');
   const isGoalTemplatesEnabled = useFeatureFlag('goalTemplatesEnabled');
+  const isPayPeriodsEnabled = useFeatureFlag('payPeriodsEnabled');
+  const { payPeriodsActive, isTogglingPayPeriods, togglePayPeriods } =
+    useTogglePayPeriods();
   const categoryExpandedState = categoryExpandedStatePref ?? 0;
 
   const numPossible = getNumPossibleMonths(
@@ -154,6 +158,13 @@ const DynamicBudgetTable = ({
             numMonths={numMonths}
             monthBounds={monthBounds}
             onMonthSelect={_onMonthSelect}
+            onTogglePayPeriods={
+              isPayPeriodsEnabled ? togglePayPeriods : undefined
+            }
+            payPeriodsActive={
+              isPayPeriodsEnabled ? payPeriodsActive : undefined
+            }
+            payPeriodsToggleDisabled={isTogglingPayPeriods}
           />
           <BudgetTable
             type={type}

--- a/packages/desktop-client/src/components/budget/MonthPicker.tsx
+++ b/packages/desktop-client/src/components/budget/MonthPicker.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import {
   SvgCheveronLeft,
   SvgCheveronRight,
+  SvgLoadBalancer,
 } from '@actual-app/components/icons/v1';
 import { SvgCalendar } from '@actual-app/components/icons/v2';
 import { styles } from '@actual-app/components/styles';
@@ -30,6 +31,9 @@ type MonthPickerProps = {
   monthBounds: MonthBounds;
   style: CSSProperties;
   onSelect: (month: string) => void;
+  onTogglePayPeriods?: () => void;
+  payPeriodsActive?: boolean;
+  payPeriodsToggleDisabled?: boolean;
 };
 
 export const MonthPicker = ({
@@ -38,6 +42,9 @@ export const MonthPicker = ({
   monthBounds,
   style,
   onSelect,
+  onTogglePayPeriods,
+  payPeriodsActive,
+  payPeriodsToggleDisabled,
 }: MonthPickerProps) => {
   const locale = useLocale();
   const { t } = useTranslation();
@@ -96,6 +103,37 @@ export const MonthPicker = ({
           justifyContent: 'center',
         }}
       >
+        {onTogglePayPeriods && (
+          <Link
+            variant="button"
+            buttonVariant="bare"
+            aria-label={t('Toggle pay period budgeting')}
+            isDisabled={payPeriodsToggleDisabled}
+            onPress={onTogglePayPeriods}
+            style={{
+              padding: '3px 3px',
+              marginRight: '12px',
+            }}
+          >
+            <View
+              title={
+                payPeriodsActive
+                  ? t('Disable pay periods')
+                  : t('Enable pay periods')
+              }
+            >
+              <SvgLoadBalancer
+                style={{
+                  width: 16,
+                  height: 16,
+                  color: payPeriodsActive
+                    ? theme.pageTextPositive
+                    : theme.pageTextSubdued,
+                }}
+              />
+            </View>
+          </Link>
+        )}
         <Link
           variant="button"
           buttonVariant="bare"

--- a/packages/desktop-client/src/components/budget/index.tsx
+++ b/packages/desktop-client/src/components/budget/index.tsx
@@ -8,7 +8,11 @@ import { View } from '@actual-app/components/view';
 import { send } from '@actual-app/core/platform/client/connection';
 import * as monthUtils from '@actual-app/core/shared/months';
 import { getPayPeriodConfig } from '@actual-app/core/shared/pay-period-config';
-import { getPayPeriodDateFilter } from '@actual-app/core/shared/pay-periods';
+import {
+  getPayPeriodDateFilter,
+  isPayPeriod,
+} from '@actual-app/core/shared/pay-periods';
+import type { PayPeriodConfig } from '@actual-app/core/shared/pay-periods';
 import type {
   CategoryEntity,
   CategoryGroupEntity,
@@ -82,12 +86,24 @@ export function Budget() {
   // tag, closing the render gate below with nothing left to reopen it.
   // The registry is the live source of the active cadence, updated during
   // render by usePayPeriodConfigSync.
+  //
+  // Matching keys are still not enough: the server can flip cadence while
+  // the request is in flight (a change synced from another device, or an
+  // undo) and answer with the rebuilt bounds before this client hears
+  // about the change. In that window both keys agree on the old cadence
+  // but the values belong to the new one, and letting them through mixes
+  // month kinds in the table. The value check drops that response; the
+  // pending config-changed announcement re-runs init with a matching pair.
   const applyBoundsIfCurrent = (
-    requestedConfigKey: string,
+    requestedConfig: PayPeriodConfig | null,
     start: string,
     end: string,
   ) => {
+    const requestedConfigKey = payPeriodConfigKey(requestedConfig);
     if (requestedConfigKey !== payPeriodConfigKey(getPayPeriodConfig())) {
+      return;
+    }
+    if (isPayPeriod(start) !== (requestedConfig != null)) {
       return;
     }
     setBounds(prev =>
@@ -105,9 +121,9 @@ export function Budget() {
       // request is in flight, the bounds it returns describe the cadence
       // that was active when it was sent, not the one active when it
       // resolves.
-      const requestedConfigKey = payPeriodConfigKey(payPeriodConfig);
+      const requestedConfig = payPeriodConfig;
       const { start, end } = await send('get-budget-bounds');
-      applyBoundsIfCurrent(requestedConfigKey, start, end);
+      applyBoundsIfCurrent(requestedConfig, start, end);
 
       await prewarmAllMonths(
         budgetType,
@@ -148,10 +164,10 @@ export function Budget() {
   }, [configKey]);
 
   const loadBoundBudgets = useEffectEvent(() => {
-    const requestedConfigKey = payPeriodConfigKey(payPeriodConfig);
+    const requestedConfig = payPeriodConfig;
     void send('get-budget-bounds')
       .then(({ start, end }) => {
-        applyBoundsIfCurrent(requestedConfigKey, start, end);
+        applyBoundsIfCurrent(requestedConfig, start, end);
       })
       .catch(error => {
         // Refreshing the bounds is an optimization; the init() bounds are

--- a/packages/desktop-client/src/components/mobile/budget/BudgetPage.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetPage.tsx
@@ -140,10 +140,17 @@ export function BudgetPage() {
       // in flight would otherwise mis-tag the bounds it returns. The
       // registry (kept live by usePayPeriodConfigSync) is checked again on
       // resolution so a response from before the change cannot overwrite
-      // the fresh bounds with a stale tag.
+      // the fresh bounds with a stale tag. The value check covers the
+      // other half of that race: the server can flip cadence mid-request
+      // and answer with the rebuilt bounds before this client hears about
+      // it, leaving both keys on the old cadence while the values belong
+      // to the new one (see the same guard in components/budget/index.tsx).
       const requestedConfigKey = configKey;
       const { start, end } = await send('get-budget-bounds');
-      if (requestedConfigKey === payPeriodConfigKey(getPayPeriodConfig())) {
+      if (
+        requestedConfigKey === payPeriodConfigKey(getPayPeriodConfig()) &&
+        isPayPeriod(start) === (requestedConfigKey !== payPeriodConfigKey(null))
+      ) {
         setMonthBounds({ start, end, configKey: requestedConfigKey });
       }
 

--- a/packages/desktop-client/src/components/mobile/budget/BudgetPage.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetPage.tsx
@@ -67,6 +67,7 @@ import { SheetNameProvider } from '#hooks/useSheetName';
 import { useSheetValue } from '#hooks/useSheetValue';
 import { useSpreadsheet } from '#hooks/useSpreadsheet';
 import { useSyncedPref } from '#hooks/useSyncedPref';
+import { useTogglePayPeriods } from '#hooks/useTogglePayPeriods';
 import { useTransactions } from '#hooks/useTransactions';
 import { useUndo } from '#hooks/useUndo';
 import { collapseModals, pushModal } from '#modals/modalsSlice';
@@ -93,6 +94,8 @@ export function BudgetPage() {
   const budgetType = isBudgetType(budgetTypePref) ? budgetTypePref : 'envelope';
   const goalTemplatesEnabled = useFeatureFlag('goalTemplatesEnabled');
   const goalTemplatesUIEnabled = useFeatureFlag('goalTemplatesUIEnabled');
+  const isPayPeriodsEnabled = useFeatureFlag('payPeriodsEnabled');
+  const { payPeriodsActive, togglePayPeriods } = useTogglePayPeriods();
   const spreadsheet = useSpreadsheet();
 
   const currMonth = monthUtils.currentBudgetMonth();
@@ -559,6 +562,13 @@ export function BudgetPage() {
     [budgetType, dispatch, onBudgetAction, onOpenBudgetMonthNotesModal],
   );
 
+  const onTogglePayPeriods = useCallback(() => {
+    // Close the menu first so the rebuild happens behind the budget page,
+    // not behind a stale modal.
+    dispatch(collapseModals({ rootModalName: 'budget-page-menu' }));
+    togglePayPeriods();
+  }, [dispatch, togglePayPeriods]);
+
   const onOpenBudgetPageMenu = useCallback(() => {
     dispatch(
       pushModal({
@@ -568,15 +578,24 @@ export function BudgetPage() {
             onAddCategoryGroup: onOpenNewCategoryGroupModal,
             onToggleHiddenCategories,
             onSwitchBudgetFile,
+            onTogglePayPeriods: isPayPeriodsEnabled
+              ? onTogglePayPeriods
+              : undefined,
+            payPeriodsActive: isPayPeriodsEnabled
+              ? payPeriodsActive
+              : undefined,
           },
         },
       }),
     );
   }, [
     dispatch,
+    isPayPeriodsEnabled,
     onOpenNewCategoryGroupModal,
     onSwitchBudgetFile,
     onToggleHiddenCategories,
+    onTogglePayPeriods,
+    payPeriodsActive,
   ]);
 
   // `monthBounds.configKey !== configKey` catches the render where the

--- a/packages/desktop-client/src/components/modals/BudgetPageMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetPageMenuModal.tsx
@@ -19,6 +19,8 @@ export function BudgetPageMenuModal({
   onAddCategoryGroup,
   onToggleHiddenCategories,
   onSwitchBudgetFile,
+  onTogglePayPeriods,
+  payPeriodsActive,
 }: BudgetPageMenuModalProps) {
   const defaultMenuItemStyle: CSSProperties = {
     ...styles.mobileMenuItem,
@@ -40,6 +42,8 @@ export function BudgetPageMenuModal({
             onAddCategoryGroup={onAddCategoryGroup}
             onToggleHiddenCategories={onToggleHiddenCategories}
             onSwitchBudgetFile={onSwitchBudgetFile}
+            onTogglePayPeriods={onTogglePayPeriods}
+            payPeriodsActive={payPeriodsActive}
           />
         </>
       )}
@@ -54,12 +58,16 @@ type BudgetPageMenuProps = Omit<
   onAddCategoryGroup: () => void;
   onToggleHiddenCategories: () => void;
   onSwitchBudgetFile: () => void;
+  onTogglePayPeriods?: () => void;
+  payPeriodsActive?: boolean;
 };
 
 function BudgetPageMenu({
   onAddCategoryGroup,
   onToggleHiddenCategories,
   onSwitchBudgetFile,
+  onTogglePayPeriods,
+  payPeriodsActive,
   ...props
 }: BudgetPageMenuProps) {
   const [showHiddenCategories] = useLocalPref('budget.showHiddenCategories');
@@ -77,6 +85,9 @@ function BudgetPageMenu({
         break;
       case 'switch-budget-file':
         onSwitchBudgetFile?.();
+        break;
+      case 'toggle-pay-periods':
+        onTogglePayPeriods?.();
         break;
       default:
         throw new Error(`Unrecognized menu item: ${name}`);
@@ -101,6 +112,16 @@ function BudgetPageMenu({
           name: 'switch-budget-file',
           text: t('Switch budget file'),
         },
+        ...(onTogglePayPeriods
+          ? [
+              {
+                name: 'toggle-pay-periods',
+                text: payPeriodsActive
+                  ? t('Disable pay period budgeting')
+                  : t('Enable pay period budgeting'),
+              },
+            ]
+          : []),
       ]}
     />
   );

--- a/packages/desktop-client/src/components/settings/PayPeriodSettings.tsx
+++ b/packages/desktop-client/src/components/settings/PayPeriodSettings.tsx
@@ -11,7 +11,7 @@ import { validatePayPeriodConfig } from '@actual-app/core/shared/pay-periods';
 import type { PayFrequency } from '@actual-app/core/shared/pay-periods';
 import type { SyncedPrefs } from '@actual-app/core/types/prefs';
 
-import { Checkbox, FormField, FormLabel } from '#components/forms';
+import { FormField, FormLabel } from '#components/forms';
 import { useSyncedPref } from '#hooks/useSyncedPref';
 import { saveSyncedPrefs } from '#prefs/prefsSlice';
 import { useDispatch } from '#redux';
@@ -58,13 +58,6 @@ export function PayPeriodSettings() {
       setIsSaving(false);
     }
   }
-
-  const onToggle = () => {
-    // Saving the pref is enough: the server rebuilds the budget sheets
-    // whenever the active pay period configuration changes (see
-    // loot-core server/budget/pay-period-config.ts).
-    void savePref({ showPayPeriods: isEnabled ? 'false' : 'true' });
-  };
 
   const commitStartDate = () => {
     if (pendingStartDate == null) {
@@ -119,44 +112,24 @@ export function PayPeriodSettings() {
             </FormField>
           </View>
 
-          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-            <Text style={{ display: 'flex' }}>
-              <Checkbox
-                id="settings-showPayPeriods"
-                checked={isEnabled}
-                disabled={isSaving || (!isEnabled && !validConfig)}
-                onChange={onToggle}
-              />
-              <label htmlFor="settings-showPayPeriods">
-                <Trans>Budget by pay period</Trans>
-              </label>
-            </Text>
-            {isSaving && (
-              <View
-                style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}
-                aria-live="polite"
-              >
-                <AnimatedLoading width={14} height={14} />
-                <Text style={{ color: theme.pageTextSubdued }}>
-                  <Trans>Rebuilding your budget…</Trans>
-                </Text>
-              </View>
-            )}
-          </View>
+          {isSaving && (
+            <View
+              style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}
+              aria-live="polite"
+            >
+              <AnimatedLoading width={14} height={14} />
+              <Text style={{ color: theme.pageTextSubdued }}>
+                <Trans>Rebuilding your budget…</Trans>
+              </Text>
+            </View>
+          )}
 
-          {!validConfig && (
+          {!validConfig && isEnabled && (
             <Text style={{ color: theme.warningText }}>
-              {isEnabled ? (
-                <Trans>
-                  Pay periods stay off until the pay frequency and payday date
-                  are valid.
-                </Trans>
-              ) : (
-                <Trans>
-                  Choose a pay frequency and a payday date to enable pay
-                  periods.
-                </Trans>
-              )}
+              <Trans>
+                Pay periods stay off until the pay frequency and payday date are
+                valid.
+              </Trans>
             </Text>
           )}
         </View>
@@ -167,7 +140,8 @@ export function PayPeriodSettings() {
           <strong>Pay periods</strong> let you budget by your actual pay
           schedule — weekly, every two weeks, or monthly — instead of by
           calendar month. Pick how often you are paid and the date of any one of
-          your paydays; your budget columns will then follow that cadence.
+          your paydays, then switch pay period budgeting on or off from the
+          budget page; your budget columns will then follow that cadence.
         </Trans>
       </Text>
     </Setting>

--- a/packages/desktop-client/src/hooks/useTogglePayPeriods.ts
+++ b/packages/desktop-client/src/hooks/useTogglePayPeriods.ts
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+
+import * as monthUtils from '@actual-app/core/shared/months';
+import type { SyncedPrefs } from '@actual-app/core/types/prefs';
+
+import { useSyncedPref } from '#hooks/useSyncedPref';
+import { saveSyncedPrefs } from '#prefs/prefsSlice';
+import { useDispatch } from '#redux';
+
+/**
+ * Switches pay period budgeting on or off from the budget page. Enabling
+ * with an incomplete configuration would leave pay periods silently off
+ * (the config would not validate), so missing prefs are defaulted to a
+ * monthly cadence anchored on the first of the current month — the
+ * settings page stays the place to refine them. All prefs go out in a
+ * single save; the server rebuilds the budget sheets before it resolves,
+ * which is what `isTogglingPayPeriods` spans.
+ */
+export function useTogglePayPeriods(): {
+  payPeriodsActive: boolean;
+  isTogglingPayPeriods: boolean;
+  togglePayPeriods: () => void;
+} {
+  const dispatch = useDispatch();
+  const [showPayPeriods] = useSyncedPref('showPayPeriods');
+  const [payPeriodFrequency] = useSyncedPref('payPeriodFrequency');
+  const [payPeriodStartDate] = useSyncedPref('payPeriodStartDate');
+  const [isTogglingPayPeriods, setIsTogglingPayPeriods] = useState(false);
+
+  const payPeriodsActive = String(showPayPeriods) === 'true';
+
+  const togglePayPeriods = () => {
+    if (isTogglingPayPeriods) {
+      return;
+    }
+
+    const prefs: SyncedPrefs = {
+      showPayPeriods: payPeriodsActive ? 'false' : 'true',
+    };
+    if (!payPeriodsActive) {
+      if (!payPeriodStartDate) {
+        prefs.payPeriodStartDate = monthUtils.firstDayOfMonth(
+          monthUtils.currentDay(),
+        );
+      }
+      if (!payPeriodFrequency) {
+        prefs.payPeriodFrequency = 'monthly';
+      }
+    }
+
+    setIsTogglingPayPeriods(true);
+    void dispatch(saveSyncedPrefs({ prefs })).finally(() => {
+      setIsTogglingPayPeriods(false);
+    });
+  };
+
+  return { payPeriodsActive, isTogglingPayPeriods, togglePayPeriods };
+}

--- a/packages/desktop-client/src/modals/modalsSlice.ts
+++ b/packages/desktop-client/src/modals/modalsSlice.ts
@@ -555,6 +555,8 @@ export type Modal =
         onAddCategoryGroup: () => void;
         onToggleHiddenCategories: () => void;
         onSwitchBudgetFile: () => void;
+        onTogglePayPeriods?: () => void;
+        payPeriodsActive?: boolean;
       };
     }
   | {

--- a/upcoming-release-notes/budget-page-pay-period-toggle.md
+++ b/upcoming-release-notes/budget-page-pay-period-toggle.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [code-with-jov]
+---
+
+Switch pay period budgeting on and off directly from the budget page instead of the settings page


### PR DESCRIPTION
Move the pay period on/off switch out of the settings page and onto the
budget page itself, following the UI of PR #96 while keeping the current
mode-switch architecture (the single refreshPayPeriodConfig funnel on the
server and the config-keyed re-initialization guard on both budget pages).

- Desktop: a load-balancer icon in the month picker toggles pay periods;
  it is tinted when active and disabled while the rebuild is in flight.
- Mobile: the budget page menu gains an "Enable/Disable pay period
  budgeting" item; selecting it closes the menu and flips the mode.
- Enabling with an incomplete configuration defaults to a monthly cadence
  anchored on the first of the current month, so the toggle always
  produces a working setup; the settings page keeps the frequency and
  payday fields for refining it.
- The settings page checkbox is removed; its rebuild indicator and the
  invalid-config warning remain.
- The pay period e2e suites now enable the mode through the new toggle
  (desktop icon, mobile menu item) instead of the settings checkbox, and
  cover the no-config default path and disabling from both surfaces.

Co-Authored-By: Claude <noreply@anthropic.com>