### PR TITLE
[AI] Default the pay periods experimental flag to on

### DIFF
--- a/packages/desktop-client/e2e/pay-periods.test.ts
+++ b/packages/desktop-client/e2e/pay-periods.test.ts
@@ -45,7 +45,9 @@ test.describe('Pay period settings', () => {
     await page?.close();
   });
 
-  test('pay period settings and toggle are hidden until the feature flag is enabled', async () => {
+  test.skip('pay period settings and toggle are hidden until the feature flag is enabled', async () => {
+    // Skipped: `payPeriodsEnabled` now defaults to true (see
+    // useFeatureFlag.ts), so this default-off assertion no longer holds.
     // Without the flag neither the settings section nor the budget page
     // toggle exists.
     let budgetPage = await navigation.goToBudgetPage();

--- a/packages/desktop-client/src/hooks/useFeatureFlag.ts
+++ b/packages/desktop-client/src/hooks/useFeatureFlag.ts
@@ -15,7 +15,7 @@ const DEFAULT_FEATURE_FLAG_STATE: Record<FeatureFlag, boolean> = {
   sankeyReport: false,
   akahuBankSync: false,
   mobileCalculator: false,
-  payPeriodsEnabled: false,
+  payPeriodsEnabled: true,
   monteCarloReport: false,
 };
 

--- a/upcoming-release-notes/default-enable-pay-periods-experimental-flag.md
+++ b/upcoming-release-notes/default-enable-pay-periods-experimental-flag.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [code-with-jov]
+---
+
+Turn on the pay periods experimental flag by default


### PR DESCRIPTION
Turns payPeriodsEnabled on by default so testers don't need to flip
it via Settings each time. The default-off regression test is
temporarily skipped since it no longer holds; the underlying
showPayPeriods per-file toggle still defaults off, so budget data
and layout are unaffected.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P6cKi38L3mxmBY6JKDbYZy