### PR TITLE
Build the Pi armv7 image from alpine.Dockerfile

### DIFF
--- a/.github/workflows/personal-pi-image.yml
+++ b/.github/workflows/personal-pi-image.yml
@@ -7,6 +7,14 @@ name: Personal - Pi image
 # cannot run on it at all - see the architecture gate in rocket-pi-3b's
 # reference/capacity.md. Building extra platforms would only burn QEMU minutes.
 #
+# Uses alpine.Dockerfile, not ubuntu.Dockerfile. Node.js stopped publishing
+# prebuilt armv7 binaries as of Node 24, so node:24-* has no linux/arm/v7
+# manifest and ubuntu.Dockerfile (FROM node:24-bookworm) can't build for this
+# platform anymore. alpine.Dockerfile sidesteps that by installing Node from
+# Alpine's own apk repo (`apk add nodejs`) instead of the upstream Node.js
+# binaries - this is the same split upstream's own docker-nightly.yml and
+# docker-release.yml use to keep publishing armv7/armv6 images.
+#
 # GHCR rather than Docker Hub: it authenticates with the built-in GITHUB_TOKEN,
 # so there are no registry secrets to create or rotate from an iPad.
 
@@ -92,7 +100,7 @@ jobs:
           context: .
           push: false
           load: true
-          file: packages/sync-server/docker/ubuntu.Dockerfile
+          file: packages/sync-server/docker/alpine.Dockerfile
           tags: actual-server-smoketest
 
       - name: Check that the image boots
@@ -107,14 +115,15 @@ jobs:
         run: docker logs smoketest || true
 
       # Reuses the layer cache from the smoke-test build where it can. The
-      # armv7 stage still compiles better-sqlite3 and bcrypt under QEMU, which
-      # is the slow part; type=gha caching keeps repeat builds tolerable.
+      # armv7 stage still compiles better-sqlite3 and bcrypt from source under
+      # QEMU (Alpine's node package has no prebuilt native modules), which is
+      # the slow part; type=gha caching keeps repeat builds tolerable.
       - name: Build and push armv7 image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           push: true
-          file: packages/sync-server/docker/ubuntu.Dockerfile
+          file: packages/sync-server/docker/alpine.Dockerfile
           platforms: linux/arm/v7
           tags: |
             ${{ env.IMAGE }}:pi


### PR DESCRIPTION
## Description

Node.js stopped publishing prebuilt armv7 binaries as of Node 24, so `node:24-bookworm` (used by `ubuntu.Dockerfile`) has no `linux/arm/v7` manifest. `personal-pi-image.yml`'s armv7 build step was failing at the base-image pull, which meant no new `actual-server:pi` image could be published to GHCR for `rocket-services` (the Pi 3 Model B this workflow deploys to).

This switches `personal-pi-image.yml` to build `alpine.Dockerfile` instead, for both the native smoke-test build and the pushed `linux/arm/v7` image. `alpine.Dockerfile` installs Node via Alpine's own `apk` repo rather than upstream Node.js binaries, so it isn't affected by the armv7 binary drop — this is the same split upstream's own `docker-nightly.yml` / `docker-release.yml` already use to keep publishing armv7/armv6 images. `alpine.Dockerfile` already existed in this fork (synced from upstream) with a compatible entrypoint and healthcheck, so no other files needed to change.

This change, and the PR description, were drafted with Claude Code.

## Related issue(s)

N/A — caught by inspecting the failing "Personal - Pi image" Actions run.

## Testing

- Confirmed via Docker Hub's registry API that `node:24-bookworm` publishes `amd64`/`arm64`/`ppc64le` manifests only (no `arm/v7`), which is what the failing build step was hitting.
- Confirmed `alpine.Dockerfile` is unchanged from upstream and already builds `linux/arm/v7` successfully there (upstream's `docker-release.yml`).
- Have not yet watched a live run of this workflow build and push under QEMU — worth confirming the armv7 build completes in a reasonable time, since Alpine compiles `better-sqlite3`/`bcrypt` from source against musl rather than using prebuilt native bindings.

## Checklist

- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed
- [ ] No obvious regressions in affected areas — pending a live workflow run


---
_Generated by [Claude Code](https://claude.ai/code/session_01UsULZ7Y7171L4iRGKX3VnF)_