### PR TITLE
[AI] Add on-demand Cloudflare Pages preview workflow for docs

### DIFF
--- a/.github/workflows/personal-preview-docs.yml
+++ b/.github/workflows/personal-preview-docs.yml
@@ -1,0 +1,60 @@
+name: Personal - Docs Preview
+
+# Optional, on-demand preview deploy of packages/docs. Never runs automatically.
+#
+# Mirrors personal-preview.yml (which deploys the app) so both personal
+# previews live on the same Cloudflare Pages setup instead of splitting
+# between Cloudflare and Netlify.
+#
+# Inert until you set the CLOUDFLARE_ENABLED repository variable to 'true' and
+# add the CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID secrets.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag or SHA to preview'
+        type: string
+        default: develop
+      project_name:
+        description: 'Cloudflare Pages project name'
+        type: string
+        default: actual-pay-periods-docs
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: Deploy docs preview
+    if: vars.CLOUDFLARE_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Set up environment
+        uses: ./.github/actions/setup
+        with:
+          download-translations: 'false'
+
+      - name: Build docs
+        run: yarn build:docs
+
+      - name: Deploy to Cloudflare Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT_NAME: ${{ inputs.project_name }}
+          DEPLOY_REF: ${{ inputs.ref }}
+        run: |
+          npx --yes wrangler@4 pages deploy packages/docs/build \
+            --project-name="$PROJECT_NAME" \
+            --branch="$DEPLOY_REF" \
+            --commit-dirty=true


### PR DESCRIPTION
Mirrors personal-preview.yml so personal docs previews use the same
Cloudflare Pages setup as the app preview instead of Netlify.